### PR TITLE
Close file descriptor created by mkstemp.

### DIFF
--- a/src/CommandRunner.cpp
+++ b/src/CommandRunner.cpp
@@ -37,9 +37,11 @@ class TemporaryFile {
  public:
   TemporaryFile() {
     char filepath[] = TEMP_FILE_TEMPLATE;
-    if (mkstemp(filepath) == -1)
+    int fd = mkstemp(filepath);
+    if (fd == -1)
       throw std::runtime_error(
           "Unable to create temporary file to run commands");
+    close(fd);
     m_filepath = std::string(filepath);
   }
 


### PR DESCRIPTION
It fixes an issue of dangling file descriptors since mkstemp also opens
the file descriptor and it was never closed.

We might want to optimize it at some point by reusing the file
descriptor instead of closing it right away.