### PR TITLE
Correctly return error when child process fails

### DIFF
--- a/src/CommandRunner.cpp
+++ b/src/CommandRunner.cpp
@@ -211,7 +211,11 @@ Try<Nothing> runCommandWithTimeout(const std::string& command,
       break;
     }
     if (rc > 0 && (WIFEXITED(status) || WIFSIGNALED(status))) {
-      break;
+      if (WIFEXITED(status) && WEXITSTATUS(status) != 0) {
+        return Error("Failed to successfully run the command \"" + command + "\", it failed with status "+ std::to_string(WEXITSTATUS(status)));
+      } else {
+        break;
+      }
     }
     tick++;
   }

--- a/tests/CommandRunnerTest.cpp
+++ b/tests/CommandRunnerTest.cpp
@@ -34,7 +34,12 @@ TEST(CommandRunnerTest, should_force_SIGKILL_inifinite_loop_command) {
 }
 
 TEST(CommandRunnerTest, should_not_crash_when_child_throws) {
-  EXPECT_NO_THROW({ CommandRunner::run(g_resourcesPath + "throw.sh", ""); });
+  EXPECT_ERROR(CommandRunner::run(g_resourcesPath + "throw.sh", ""));
+  EXPECT_ERROR_MESSAGE(CommandRunner::run(g_resourcesPath + "throw.sh", ""), "Failed to successfully run the command \"/src/mesos-command-modules/tests/scripts/throw.sh\", it failed with status 1");
+}
+
+TEST(CommandRunnerTest, should_not_return_error_when_script_works) {
+  EXPECT_SOME(CommandRunner::run(g_resourcesPath + "ok.sh", ""));
 }
 
 TEST(CommandRunnerTest, should_not_crash_when_executing_unexisting_command) {

--- a/tests/gtest_helpers.hpp
+++ b/tests/gtest_helpers.hpp
@@ -18,4 +18,8 @@
   EXPECT_FALSE(futureResult.wait_for(std::chrono::milliseconds(X)) !=          \
                std::future_status::timeout);
 
+#define EXPECT_ERROR_MESSAGE(actual, expectedMessage)                    \
+  EXPECT_TRUE(actual.isError());                                         \
+  EXPECT_EQ(actual.error(), expectedMessage);
+
 #endif

--- a/tests/scripts/ok.sh
+++ b/tests/scripts/ok.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exit 0


### PR DESCRIPTION
If our command fails we want task creation to be considered as failed.

It is up to the command to decide whether to accept the task spawn or
not.