### PR TITLE
Use regexp to test should_not_crash_when_child_throws

### DIFF
--- a/tests/CommandRunnerTest.cpp
+++ b/tests/CommandRunnerTest.cpp
@@ -4,6 +4,7 @@
 #include "gtest_helpers.hpp"
 
 #include <stout/gtest.hpp>
+#include <regex>
 
 using std::string;
 
@@ -35,7 +36,7 @@ TEST(CommandRunnerTest, should_force_SIGKILL_inifinite_loop_command) {
 
 TEST(CommandRunnerTest, should_not_crash_when_child_throws) {
   EXPECT_ERROR(CommandRunner::run(g_resourcesPath + "throw.sh", ""));
-  EXPECT_ERROR_MESSAGE(CommandRunner::run(g_resourcesPath + "throw.sh", ""), "Failed to successfully run the command \"/src/mesos-command-modules/tests/scripts/throw.sh\", it failed with status 1");
+  EXPECT_ERROR_MESSAGE(CommandRunner::run(g_resourcesPath + "throw.sh", ""), std::regex("Failed to successfully run the command .*throw.sh\", it failed with status 1"));
 }
 
 TEST(CommandRunnerTest, should_not_return_error_when_script_works) {

--- a/tests/gtest_helpers.hpp
+++ b/tests/gtest_helpers.hpp
@@ -20,6 +20,6 @@
 
 #define EXPECT_ERROR_MESSAGE(actual, expectedMessage)                    \
   EXPECT_TRUE(actual.isError());                                         \
-  EXPECT_EQ(actual.error(), expectedMessage);
+  EXPECT_TRUE(std::regex_match(actual.error(), expectedMessage));
 
 #endif


### PR DESCRIPTION
This will avoid to rely on test being executed on a travis-like
environment

Change-Id: Ia9568a08077f931c12347955ce602b717d92a423