### PR TITLE
Improve logging by prepending log lines with identifiers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ set(MODULES_HEADERS
   ${CMAKE_SOURCE_DIR}/src/CommandIsolator.hpp
   ${CMAKE_SOURCE_DIR}/src/CommandRunner.hpp
   ${CMAKE_SOURCE_DIR}/src/Helpers.hpp
+  ${CMAKE_SOURCE_DIR}/src/Logger.hpp
   ${CMAKE_SOURCE_DIR}/src/ModulesFactory.hpp
 )
 

--- a/src/CommandRunner.cpp
+++ b/src/CommandRunner.cpp
@@ -25,7 +25,6 @@
 
 namespace criteo {
 namespace mesos {
-namespace CommandRunner {
 
 using std::string;
 using std::vector;
@@ -101,7 +100,7 @@ inline bool isFileExecutable(const std::string& name) {
  * @return The pid of the child process.
  */
 pid_t popen2(const std::string& command, const std::vector<std::string>& args,
-             int* infp = NULL, int* outfp = NULL) {
+             int* infp = nullptr, int* outfp = nullptr) {
   int p_stdin[2], p_stdout[2];
   pid_t pid;
   if (pipe(p_stdin) != 0 || pipe(p_stdout) != 0) {
@@ -141,13 +140,13 @@ pid_t popen2(const std::string& command, const std::vector<std::string>& args,
   }
 
   // executed in parent
-  if (infp == NULL) {
+  if (infp == nullptr) {
     close(p_stdin[WRITE]);
   } else {
     *infp = p_stdin[WRITE];
   }
   close(p_stdin[READ]);
-  if (outfp == NULL) {
+  if (outfp == nullptr) {
     close(p_stdout[READ]);
   } else {
     *outfp = p_stdout[READ];
@@ -168,7 +167,8 @@ pid_t popen2(const std::string& command, const std::vector<std::string>& args,
  */
 Try<Nothing> runCommandWithTimeout(const std::string& command,
                                    const std::vector<std::string>& args,
-                                   int timeout) {
+                                   unsigned int timeout,
+                                   const logging::Metadata& loggingMetadata) {
   int status;
   unsigned int tick = 0;
   const unsigned int SECONDS = 1000000000;
@@ -191,21 +191,21 @@ Try<Nothing> runCommandWithTimeout(const std::string& command,
   pid_t pid = popen2(command, args);
 
   while (tick < totalTicks) {
-    nanosleep(&timeoutSpec, NULL);
+    nanosleep(&timeoutSpec, nullptr);
     if (tick == processTicks) {
       hasError = true;
-      LOG(WARNING) << "External command took too long to exit. "
-                   << "Sending SIGTERM...";
+      TASK_LOG(WARNING, loggingMetadata) << "External command took too long to exit. "
+        << "Sending SIGTERM...";
       if (kill(pid, SIGTERM) == -1) {
-        LOG(ERROR) << "Failed to send SIGTERM: " << strerror(errno);
+        TASK_LOG(ERROR, loggingMetadata) << "Failed to send SIGTERM: " << strerror(errno);
         break;
       }
     }
 
     int rc = waitpid(pid, &status, WNOHANG);
     if (rc < 0) {
-      LOG(ERROR) << "Error when waiting for child process running the "
-                 << "external command: " << strerror(errno);
+      TASK_LOG(ERROR, loggingMetadata) << "Error when waiting for child process running the "
+        << "external command: " << strerror(errno);
       hasError = true;
       forceKill = true;
       break;
@@ -221,10 +221,10 @@ Try<Nothing> runCommandWithTimeout(const std::string& command,
   }
 
   if (forceKill || tick == totalTicks) {
-    LOG(WARNING) << "External command is still running. Sending SIGKILL...";
+    TASK_LOG(WARNING, loggingMetadata) << "External command is still running. Sending SIGKILL...";
     if (kill(pid, SIGKILL) == -1) {
       hasError = true;
-      LOG(ERROR) << "Failed to kill the command: " << strerror(errno);
+      TASK_LOG(ERROR, loggingMetadata) << "Failed to kill the command: " << strerror(errno);
     } else {
       return Error("Command \"" + command + "\" took too long to return");
     }
@@ -234,6 +234,11 @@ Try<Nothing> runCommandWithTimeout(const std::string& command,
     return Error("Failed to successfully run the command \"" + command + "\"");
   }
   return Nothing();
+}
+
+CommandRunner::CommandRunner(bool debug, const logging::Metadata& loggingMetadata)
+    : m_debug(debug), m_loggingMetadata(loggingMetadata)
+{
 }
 
 /*
@@ -251,35 +256,39 @@ Try<Nothing> runCommandWithTimeout(const std::string& command,
  *
  * @return The output of the command read from the output file.
  */
-Try<std::string> run(const std::string& command, const std::string& input,
-                     int timeout, bool debug) {
+Try<std::string> CommandRunner::run(
+  const std::string& command,
+  const std::string& input,
+  unsigned int timeout) {
+
   try {
     TemporaryFile inputFile;
     TemporaryFile outputFile;
     inputFile.write(input);
 
-    if (debug) {
-      LOG(INFO) << "[DEBUG] Fork and execute: " << command << " "
+    if (m_debug) {
+      TASK_LOG(INFO, m_loggingMetadata) << "Calling command: \"" << command << "\" "
                 << inputFile.filepath() << " " << outputFile.filepath();
+    } else {
+      TASK_LOG(INFO, m_loggingMetadata) << "Calling command: \"" << command << "\"";
     }
 
     vector<string> args;
     args.push_back(inputFile.filepath());
     args.push_back(outputFile.filepath());
 
-    Try<Nothing> result = runCommandWithTimeout(command, args, timeout);
+    Try<Nothing> result = runCommandWithTimeout(command, args, timeout, m_loggingMetadata);
     if (result.isError()) {
       throw std::runtime_error(result.error());
     }
 
     return outputFile.readAll();
   } catch (const std::runtime_error& e) {
-    if (debug) {
-      return Error(string(e.what()) + ". Input was \"" + input + "\"");
+    if (m_debug) {
+      return Error("[DEBUG] " + string(e.what()) + ". Input was \"" + input + "\"");
     }
     return Error(e.what());
   }
-}
 }
 }
 }

--- a/src/CommandRunner.hpp
+++ b/src/CommandRunner.hpp
@@ -5,33 +5,49 @@
 
 #include <stout/try.hpp>
 
+#include "Logger.hpp"
+
 namespace criteo {
 namespace mesos {
-namespace CommandRunner {
 
-/**
- * Run command receiving two paths to temporary files as input. The first is
- * the file containing the serialized input passed to the command and the
- * second one is the file where the command can log its outputs.
- *
- * The command must exit in less than the timeout given as parameter,
- * otherwise the process receives a SIGTERM and then a SIGKILL if it still has
- * not exited. SIGKILL is sent one second after the end of the timeout if the
- * process is still running after SIGTERM.
- *
- * @param command The command to run.
- * @param serializedInput The serialized input passed to the command through
- *   the temporary file.
- * @param timeout The time in seconds for the command to terminate before
- *   being killed.
- * @param debug Flag enabling the debug mode logging all inputs and outputs.
- *
- * @return The output of the command retrieved from the temporary file.
- */
-Try<std::string> run(const std::string& command,
-                     const std::string& serializedInput, int timeout = 40,
-                     bool debug = false);
-}
+class CommandRunner {
+public:
+    /**
+     * @brief CommandRunner
+     * @param debug true to publish debug level information, false otherwise.
+     * @param loggingMetadata The metadata like task id prepended to logs.
+     */
+    CommandRunner(bool debug, const logging::Metadata& loggingMetadata);
+
+    /**
+     * Run command receiving two paths to temporary files as input. The first is
+     * the file containing the serialized input passed to the command and the
+     * second one is the file where the command can log its outputs.
+     *
+     * The command must exit in less than the timeout given as parameter,
+     * otherwise the process receives a SIGTERM and then a SIGKILL if it still has
+     * not exited. SIGKILL is sent one second after the end of the timeout if the
+     * process is still running after SIGTERM.
+     *
+     * @param command The command to run.
+     * @param serializedInput The serialized input passed to the command through
+     *   the temporary file.
+     * @param timeout The time in seconds for the command to terminate before
+     *   being killed.
+     * @param debug Flag enabling the debug mode logging all inputs and outputs.
+     *
+     * @return The output of the command retrieved from the temporary file.
+     */
+    Try<std::string> run(
+        const std::string& command,
+        const std::string& serializedInput,
+        unsigned int timeout);
+
+private:
+    bool m_debug;
+    logging::Metadata m_loggingMetadata;
+};
+
 }
 }
 

--- a/src/Helpers.hpp
+++ b/src/Helpers.hpp
@@ -14,9 +14,7 @@ Result<Proto> jsonToProtobuf(const std::string& output) {
 
   auto outputJsonTry = JSON::parse(output);
   if (outputJsonTry.isError()) {
-    LOG(WARNING) << "Error when parsing string to JSON:"
-                 << outputJsonTry.error();
-    return Error("Malformed JSON");
+    return Error("Malformed JSON. " + outputJsonTry.error());
   }
 
   auto outputJson = outputJsonTry.get();
@@ -26,8 +24,7 @@ Result<Proto> jsonToProtobuf(const std::string& output) {
 
   auto proto = ::protobuf::parse<Proto>(outputJson);
   if (proto.isError()) {
-    LOG(WARNING) << "Error while converting JSON to protobuf: "
-                 << proto.error();
+    return Error("Error while converting JSON to protobuf. " + proto.error());
   }
   return proto;
 }

--- a/src/Logger.hpp
+++ b/src/Logger.hpp
@@ -1,0 +1,20 @@
+#ifndef __LOGGING_LOGGER_HPP__
+#define __LOGGING_LOGGER_HPP__
+
+#include <string>
+
+#define TASK_LOG(severity, metadata) \
+    LOG(severity) << "[TASK=" << metadata.taskId << ", METHOD=" << metadata.method << "] "
+
+namespace criteo {
+namespace mesos {
+namespace logging {
+struct Metadata {
+    std::string taskId;
+    std::string method;
+};
+}
+}
+}
+
+#endif


### PR DESCRIPTION
In order to better track what happens for a given container in Mesos logs
we need to correlate prepare and cleanup operation with some kind of
identifier. We take the identifiers provided with the container to
keep track of it.

NOTE: unfortunately the identifier is different for an isolator and
a hook because different information is provided in each case.