### PR TITLE
Make command timeouts configurable.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ set(MODULES_HEADERS
   ${CMAKE_SOURCE_DIR}/src/CommandIsolator.hpp
   ${CMAKE_SOURCE_DIR}/src/CommandRunner.hpp
   ${CMAKE_SOURCE_DIR}/src/Helpers.hpp
+  ${CMAKE_SOURCE_DIR}/src/Logger.hpp
   ${CMAKE_SOURCE_DIR}/src/ModulesFactory.hpp
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,13 +52,16 @@ set(MODULES_SOURCES
   ${CMAKE_SOURCE_DIR}/src/CommandHook.cpp
   ${CMAKE_SOURCE_DIR}/src/CommandIsolator.cpp
   ${CMAKE_SOURCE_DIR}/src/CommandRunner.cpp
+  ${CMAKE_SOURCE_DIR}/src/ConfigurationParser.cpp
   ${CMAKE_SOURCE_DIR}/src/ModulesFactory.cpp
 )
 
 set(MODULES_HEADERS
+  ${CMAKE_SOURCE_DIR}/src/Command.hpp
   ${CMAKE_SOURCE_DIR}/src/CommandHook.hpp
   ${CMAKE_SOURCE_DIR}/src/CommandIsolator.hpp
   ${CMAKE_SOURCE_DIR}/src/CommandRunner.hpp
+  ${CMAKE_SOURCE_DIR}/src/ConfigurationParser.hpp
   ${CMAKE_SOURCE_DIR}/src/Helpers.hpp
   ${CMAKE_SOURCE_DIR}/src/Logger.hpp
   ${CMAKE_SOURCE_DIR}/src/ModulesFactory.hpp
@@ -74,6 +77,7 @@ set(TEST_SOURCES
   ${CMAKE_SOURCE_DIR}/tests/CommandRunnerTest.cpp
   ${CMAKE_SOURCE_DIR}/tests/CommandHookTest.cpp
   ${CMAKE_SOURCE_DIR}/tests/CommandIsolatorTest.cpp
+  ${CMAKE_SOURCE_DIR}/tests/ConfigurationParserTest.cpp
   ${CMAKE_SOURCE_DIR}/tests/ModulesFactoryTest.cpp
 )
 

--- a/README.md
+++ b/README.md
@@ -36,15 +36,15 @@ commands.
           "name": "com_criteo_mesos_CommandHook",
           "parameters": [
             {
-              "key": "hook_slave_run_task_label_decorator",
+              "key": "hook_slave_run_task_label_decorator_command",
               "value": "/opt/mesos/modules/slaveRunTaskLabelDecorator.sh"
             },
             {
-              "key": "hook_slave_executor_environment_decorator",
+              "key": "hook_slave_executor_environment_decorator_command",
               "value": "/opt/mesos/modules/slaveExecutorEnvironmentDecorator.sh"
             },
             {
-              "key": "hook_slave_remove_executor_hook",
+              "key": "hook_slave_remove_executor_hook_command",
               "value": "/opt/mesos/modules/slaveRemoveExecutorHook.sh"
             },
             {
@@ -57,11 +57,15 @@ commands.
           "name": "com_criteo_mesos_CommandIsolator",
           "parameters": [
             {
-              "key": "isolator_prepare",
+              "key": "isolator_prepare_command",
               "value": "/opt/mesos/modules/prepare.sh"
             },
             {
-              "key": "isolator_cleanup",
+              "key": "isolator_prepare_timeout",
+              "value": "10"
+            },
+            {
+              "key": "isolator_cleanup_command",
               "value": "/opt/mesos/modules/cleanup.sh"
             },
             {

--- a/src/Command.hpp
+++ b/src/Command.hpp
@@ -6,8 +6,14 @@
 namespace criteo {
 namespace mesos {
 
+// This is the default value of the timeout if the user does not override it
+// in configuration.
 const unsigned long DEFAULT_COMMAND_TIMEOUT = 30;
 
+/**
+ * @brief The Command class represents a command, i.e., a command to be run and a timeout before
+ * the command is terminated.
+ */
 class Command {
 public:
   Command(const std::string& command): m_cmd(command), m_timeout(DEFAULT_COMMAND_TIMEOUT) {}

--- a/src/Command.hpp
+++ b/src/Command.hpp
@@ -1,0 +1,33 @@
+#ifndef COMMAND_HPP
+#define COMMAND_HPP
+
+#include <string>
+
+namespace criteo {
+namespace mesos {
+
+const unsigned long DEFAULT_COMMAND_TIMEOUT = 30;
+
+class Command {
+public:
+  Command(const std::string& command): m_cmd(command), m_timeout(DEFAULT_COMMAND_TIMEOUT) {}
+  Command(const std::string& command, unsigned long timeout): m_cmd(command), m_timeout(timeout) {}
+
+  bool operator==(const Command& that) const {
+    return m_cmd == that.m_cmd && m_timeout == that.m_timeout;
+  }
+
+  inline const std::string& command() const { return m_cmd; }
+  inline unsigned long timeout() const { return m_timeout; }
+
+  void setTimeout(const unsigned long timeout) { m_timeout = timeout; }
+
+private:
+  std::string m_cmd;
+  unsigned long m_timeout;
+};
+
+}
+}
+
+#endif

--- a/src/CommandHook.hpp
+++ b/src/CommandHook.hpp
@@ -3,8 +3,12 @@
 
 #include <string>
 
+#include <Command.hpp>
+
 #include <mesos/hook.hpp>
 #include <mesos/module/hook.hpp>
+
+#include <stout/option.hpp>
 
 namespace criteo {
 namespace mesos {
@@ -32,10 +36,12 @@ class CommandHook : public ::mesos::Hook {
    * @param isDebugMode If true, logs inputs and outputs of the commands,
    *   otherwise logs nothing
    */
-  CommandHook(const std::string &runTaskLabelCommand,
-              const std::string &executorEnvironmentCommand,
-              const std::string &removeExecutorCommand,
-              bool isDebugMode = false);
+  explicit CommandHook(
+    const Option<Command> &runTaskLabelCommand,
+    const Option<Command> &executorEnvironmentCommand,
+    const Option<Command> &removeExecutorCommand,
+    bool isDebugMode = false);
+
   virtual ~CommandHook() {}
 
   /*
@@ -81,22 +87,22 @@ class CommandHook : public ::mesos::Hook {
       const ::mesos::FrameworkInfo &frameworkInfo,
       const ::mesos::ExecutorInfo &executorInfo) override;
 
-  inline const std::string &runTaskLabelCommand() const {
+  inline const Option<Command> &runTaskLabelCommand() const {
     return m_runTaskLabelCommand;
   }
 
-  inline const std::string &executorEnvironmentCommand() const {
+  inline const Option<Command> &executorEnvironmentCommand() const {
     return m_executorEnvironmentCommand;
   }
 
-  inline const std::string &removeExecutorCommand() const {
+  inline const Option<Command> &removeExecutorCommand() const {
     return m_removeExecutorCommand;
   }
 
  private:
-  std::string m_runTaskLabelCommand;
-  std::string m_executorEnvironmentCommand;
-  std::string m_removeExecutorCommand;
+  Option<Command> m_runTaskLabelCommand;
+  Option<Command> m_executorEnvironmentCommand;
+  Option<Command> m_removeExecutorCommand;
   bool m_isDebugMode;
 };
 }

--- a/src/CommandIsolator.hpp
+++ b/src/CommandIsolator.hpp
@@ -3,8 +3,12 @@
 
 #include <string>
 
+#include "Command.hpp"
+
 #include <mesos/module/isolator.hpp>
 #include <mesos/slave/isolator.hpp>
+
+#include <stout/option.hpp>
 
 namespace criteo {
 namespace mesos {
@@ -24,7 +28,7 @@ class CommandIsolator : public ::mesos::slave::Isolator {
  public:
   /*
    * Constructor
-   * Each argument can be empty. In that case the corresponding
+   * In the case a command is empty, the corresponding
    * isolation primitive will not be treated.
    *
    * @param prepareCommand The command to execute when `prepare` event is
@@ -34,8 +38,10 @@ class CommandIsolator : public ::mesos::slave::Isolator {
    * @param isDebugMode If true, logs inputs and outputs of the commands,
    *   otherwise logs nothing
    */
-  CommandIsolator(const std::string& prepareCommand,
-                  const std::string& cleanupCommand, bool isDebugMode = false);
+  explicit CommandIsolator(
+    const Option<Command>& prepareCommand,
+    const Option<Command>& cleanupCommand,
+    bool isDebugMode = false);
 
   /**
    * Destructor
@@ -69,12 +75,12 @@ class CommandIsolator : public ::mesos::slave::Isolator {
   /**
    * Get prepare command.
    */
-  const std::string& prepareCommand() const;
+  const Option<Command>& prepareCommand() const;
 
   /**
    * Get cleanup command.
    */
-  const std::string& cleanupCommand() const;
+  const Option<Command>& cleanupCommand() const;
 
  private:
   CommandIsolatorProcess* m_process;

--- a/src/CommandRunner.cpp
+++ b/src/CommandRunner.cpp
@@ -167,7 +167,7 @@ pid_t popen2(const std::string& command, const std::vector<std::string>& args,
  */
 Try<Nothing> runCommandWithTimeout(const std::string& command,
                                    const std::vector<std::string>& args,
-                                   unsigned int timeout,
+                                   unsigned long timeout,
                                    const logging::Metadata& loggingMetadata) {
   int status;
   unsigned int tick = 0;
@@ -257,9 +257,8 @@ CommandRunner::CommandRunner(bool debug, const logging::Metadata& loggingMetadat
  * @return The output of the command read from the output file.
  */
 Try<std::string> CommandRunner::run(
-  const std::string& command,
-  const std::string& input,
-  unsigned int timeout) {
+  const Command& command,
+  const std::string& input) {
 
   try {
     TemporaryFile inputFile;
@@ -267,17 +266,17 @@ Try<std::string> CommandRunner::run(
     inputFile.write(input);
 
     if (m_debug) {
-      TASK_LOG(INFO, m_loggingMetadata) << "Calling command: \"" << command << "\" "
+      TASK_LOG(INFO, m_loggingMetadata) << "Calling command: \"" << command.command() << "\" (" << command.timeout() << "s) "
                 << inputFile.filepath() << " " << outputFile.filepath();
     } else {
-      TASK_LOG(INFO, m_loggingMetadata) << "Calling command: \"" << command << "\"";
+      TASK_LOG(INFO, m_loggingMetadata) << "Calling command: \"" << command.command() << "\" (" << command.timeout() << "s)";
     }
 
     vector<string> args;
     args.push_back(inputFile.filepath());
     args.push_back(outputFile.filepath());
 
-    Try<Nothing> result = runCommandWithTimeout(command, args, timeout, m_loggingMetadata);
+    Try<Nothing> result = runCommandWithTimeout(command.command(), args, command.timeout(), m_loggingMetadata);
     if (result.isError()) {
       throw std::runtime_error(result.error());
     }

--- a/src/CommandRunner.cpp
+++ b/src/CommandRunner.cpp
@@ -25,7 +25,6 @@
 
 namespace criteo {
 namespace mesos {
-namespace CommandRunner {
 
 using std::string;
 using std::vector;
@@ -101,7 +100,7 @@ inline bool isFileExecutable(const std::string& name) {
  * @return The pid of the child process.
  */
 pid_t popen2(const std::string& command, const std::vector<std::string>& args,
-             int* infp = NULL, int* outfp = NULL) {
+             int* infp = nullptr, int* outfp = nullptr) {
   int p_stdin[2], p_stdout[2];
   pid_t pid;
   if (pipe(p_stdin) != 0 || pipe(p_stdout) != 0) {
@@ -141,13 +140,13 @@ pid_t popen2(const std::string& command, const std::vector<std::string>& args,
   }
 
   // executed in parent
-  if (infp == NULL) {
+  if (infp == nullptr) {
     close(p_stdin[WRITE]);
   } else {
     *infp = p_stdin[WRITE];
   }
   close(p_stdin[READ]);
-  if (outfp == NULL) {
+  if (outfp == nullptr) {
     close(p_stdout[READ]);
   } else {
     *outfp = p_stdout[READ];
@@ -168,7 +167,8 @@ pid_t popen2(const std::string& command, const std::vector<std::string>& args,
  */
 Try<Nothing> runCommandWithTimeout(const std::string& command,
                                    const std::vector<std::string>& args,
-                                   int timeout) {
+                                   unsigned int timeout,
+                                   const logging::Metadata& loggingMetadata) {
   int status;
   unsigned int tick = 0;
   const unsigned int SECONDS = 1000000000;
@@ -191,21 +191,21 @@ Try<Nothing> runCommandWithTimeout(const std::string& command,
   pid_t pid = popen2(command, args);
 
   while (tick < totalTicks) {
-    nanosleep(&timeoutSpec, NULL);
+    nanosleep(&timeoutSpec, nullptr);
     if (tick == processTicks) {
       hasError = true;
-      LOG(WARNING) << "External command took too long to exit. "
-                   << "Sending SIGTERM...";
+      TASK_LOG(WARNING, loggingMetadata) << "External command took too long to exit. "
+        << "Sending SIGTERM...";
       if (kill(pid, SIGTERM) == -1) {
-        LOG(ERROR) << "Failed to send SIGTERM: " << strerror(errno);
+        TASK_LOG(ERROR, loggingMetadata) << "Failed to send SIGTERM: " << strerror(errno);
         break;
       }
     }
 
     int rc = waitpid(pid, &status, WNOHANG);
     if (rc < 0) {
-      LOG(ERROR) << "Error when waiting for child process running the "
-                 << "external command: " << strerror(errno);
+      TASK_LOG(ERROR, loggingMetadata) << "Error when waiting for child process running the "
+        << "external command: " << strerror(errno);
       hasError = true;
       forceKill = true;
       break;
@@ -221,10 +221,10 @@ Try<Nothing> runCommandWithTimeout(const std::string& command,
   }
 
   if (forceKill || tick == totalTicks) {
-    LOG(WARNING) << "External command is still running. Sending SIGKILL...";
+    TASK_LOG(WARNING, loggingMetadata) << "External command is still running. Sending SIGKILL...";
     if (kill(pid, SIGKILL) == -1) {
       hasError = true;
-      LOG(ERROR) << "Failed to kill the command: " << strerror(errno);
+      TASK_LOG(ERROR, loggingMetadata) << "Failed to kill the command: " << strerror(errno);
     } else {
       return Error("Command \"" + command + "\" took too long to return");
     }
@@ -234,6 +234,11 @@ Try<Nothing> runCommandWithTimeout(const std::string& command,
     return Error("Failed to successfully run the command \"" + command + "\"");
   }
   return Nothing();
+}
+
+CommandRunner::CommandRunner(bool debug, const logging::Metadata& loggingMetadata)
+    : m_debug(debug), m_loggingMetadata(loggingMetadata)
+{
 }
 
 /*
@@ -251,35 +256,39 @@ Try<Nothing> runCommandWithTimeout(const std::string& command,
  *
  * @return The output of the command read from the output file.
  */
-Try<std::string> run(const std::string& command, const std::string& input,
-                     int timeout, bool debug) {
+Try<std::string> CommandRunner::run(
+  const std::string& command,
+  const std::string& input,
+  unsigned int timeout) {
+
   try {
     TemporaryFile inputFile;
     TemporaryFile outputFile;
     inputFile.write(input);
 
-    if (debug) {
-      LOG(INFO) << "[DEBUG] Fork and execute: " << command << " "
+    if (m_debug) {
+      TASK_LOG(INFO, m_loggingMetadata) << "Calling command: \"" << command << "\" "
                 << inputFile.filepath() << " " << outputFile.filepath();
+    } else {
+      TASK_LOG(INFO, m_loggingMetadata) << "Calling command: \"" << command << "\"";
     }
 
     vector<string> args;
     args.push_back(inputFile.filepath());
     args.push_back(outputFile.filepath());
 
-    Try<Nothing> result = runCommandWithTimeout(command, args, timeout);
+    Try<Nothing> result = runCommandWithTimeout(command, args, timeout, m_loggingMetadata);
     if (result.isError()) {
       throw std::runtime_error(result.error());
     }
 
     return outputFile.readAll();
   } catch (const std::runtime_error& e) {
-    if (debug) {
-      return Error(string(e.what()) + ". Input was \"" + input + "\"");
+    if (m_debug) {
+      return Error("[DEBUG] " + string(e.what()) + ". Input was \"" + input + "\"");
     }
     return Error(e.what());
   }
-}
 }
 }
 }

--- a/src/CommandRunner.hpp
+++ b/src/CommandRunner.hpp
@@ -5,33 +5,49 @@
 
 #include <stout/try.hpp>
 
+#include "Logger.hpp"
+
 namespace criteo {
 namespace mesos {
-namespace CommandRunner {
 
-/**
- * Run command receiving two paths to temporary files as input. The first is
- * the file containing the serialized input passed to the command and the
- * second one is the file where the command can log its outputs.
- *
- * The command must exit in less than the timeout given as parameter,
- * otherwise the process receives a SIGTERM and then a SIGKILL if it still has
- * not exited. SIGKILL is sent one second after the end of the timeout if the
- * process is still running after SIGTERM.
- *
- * @param command The command to run.
- * @param serializedInput The serialized input passed to the command through
- *   the temporary file.
- * @param timeout The time in seconds for the command to terminate before
- *   being killed.
- * @param debug Flag enabling the debug mode logging all inputs and outputs.
- *
- * @return The output of the command retrieved from the temporary file.
- */
-Try<std::string> run(const std::string& command,
-                     const std::string& serializedInput, int timeout = 40,
-                     bool debug = false);
-}
+class CommandRunner {
+public:
+    /**
+     * @brief CommandRunner
+     * @param debug true to publish debug level information, false otherwise.
+     * @param loggingMetadata The metadata like task id prepended to logs.
+     */
+    CommandRunner(bool debug, const logging::Metadata& loggingMetadata);
+
+    /**
+     * Run command receiving two paths to temporary files as input. The first is
+     * the file containing the serialized input passed to the command and the
+     * second one is the file where the command can log its outputs.
+     *
+     * The command must exit in less than the timeout given as parameter,
+     * otherwise the process receives a SIGTERM and then a SIGKILL if it still has
+     * not exited. SIGKILL is sent one second after the end of the timeout if the
+     * process is still running after SIGTERM.
+     *
+     * @param command The command to run.
+     * @param serializedInput The serialized input passed to the command through
+     *   the temporary file.
+     * @param timeout The time in seconds for the command to terminate before
+     *   being killed.
+     * @param debug Flag enabling the debug mode logging all inputs and outputs.
+     *
+     * @return The output of the command retrieved from the temporary file.
+     */
+    Try<std::string> run(
+        const std::string& command,
+        const std::string& serializedInput,
+        unsigned int timeout);
+
+private:
+    bool m_debug;
+    logging::Metadata m_loggingMetadata;
+};
+
 }
 }
 

--- a/src/CommandRunner.hpp
+++ b/src/CommandRunner.hpp
@@ -5,6 +5,7 @@
 
 #include <stout/try.hpp>
 
+#include "Command.hpp"
 #include "Logger.hpp"
 
 namespace criteo {
@@ -39,9 +40,8 @@ public:
      * @return The output of the command retrieved from the temporary file.
      */
     Try<std::string> run(
-        const std::string& command,
-        const std::string& serializedInput,
-        unsigned int timeout);
+        const Command& command,
+        const std::string& serializedInput);
 
 private:
     bool m_debug;

--- a/src/ConfigurationParser.cpp
+++ b/src/ConfigurationParser.cpp
@@ -1,0 +1,75 @@
+#include "ConfigurationParser.hpp"
+
+#include <stout/foreach.hpp>
+
+namespace criteo {
+namespace mesos {
+
+using std::map;
+using std::stoul;
+using std::string;
+
+// Hook commands.
+const string SLAVE_RUN_TASK_LABEL_DECORATOR_KEY =
+    "hook_slave_run_task_label_decorator";
+const string SLAVE_EXECUTOR_ENVIRONMENT_DECORATOR_KEY =
+    "hook_slave_executor_environment_decorator";
+const string SLAVE_REMOVE_EXECUTOR_KEY = "hook_slave_remove_executor_hook";
+
+// Isolator commands.
+const string PREPARE_KEY = "isolator_prepare";
+const string CLEANUP_KEY = "isolator_cleanup";
+
+// Additional parameters.
+const string DEBUG_KEY = "debug"; // enable debug mode.
+
+string getOrEmpty(const map<string, string>& kv, const string& key) {
+  string command;
+  auto it = kv.find(key);
+  if (it != kv.end()) command = it->second;
+  return command;
+}
+
+map<string, string> toMap(const ::mesos::Parameters& parameters) {
+  map<string, string> kv;
+  foreach (const ::mesos::Parameter& parameter, parameters.parameter()) {
+    if (parameter.has_key() && parameter.has_value()) {
+      kv[parameter.key()] = parameter.value();
+    }
+  }
+  return kv;
+}
+
+Option<Command> extractCommand(const map<string, string>& kv, const std::string& commandKey) {
+    string cmd = getOrEmpty(kv, commandKey + "_command");
+    if (!cmd.empty()) {
+        Command command = Command(cmd);
+
+        string timeoutStr = getOrEmpty(kv, commandKey + "_timeout");
+        if (timeoutStr.empty()) {
+            return Option<Command>(command);
+        }
+        unsigned long timeout = stoul(timeoutStr);
+        command.setTimeout(timeout);
+        return Option<Command>(command);
+    }
+    return Option<Command>();
+}
+
+Configuration ConfigurationParser::parse(const ::mesos::Parameters& parameters) {
+    map<string, string> p = toMap(parameters);
+    Configuration configuration;
+
+    configuration.slaveExecutorEnvironmentDecoratorCommand = extractCommand(p, SLAVE_EXECUTOR_ENVIRONMENT_DECORATOR_KEY);
+    configuration.slaveRemoveExecutorHookCommand = extractCommand(p, SLAVE_REMOVE_EXECUTOR_KEY);
+    configuration.slaveRunTaskLabelDecoratorCommand = extractCommand(p, SLAVE_RUN_TASK_LABEL_DECORATOR_KEY);
+
+    configuration.prepareCommand = extractCommand(p, PREPARE_KEY);
+    configuration.cleanupCommand = extractCommand(p, CLEANUP_KEY);
+
+    configuration.isDebugSet = getOrEmpty(p, DEBUG_KEY) == "true";
+    return configuration;
+}
+
+}
+}

--- a/src/ConfigurationParser.hpp
+++ b/src/ConfigurationParser.hpp
@@ -1,0 +1,31 @@
+#ifndef CONFIGURATION_PARSER_HPP
+#define CONFIGURATION_PARSER_HPP
+
+#include <stout/option.hpp>
+#include <mesos/mesos.pb.h>
+
+#include "Command.hpp"
+
+namespace criteo {
+namespace mesos {
+
+struct Configuration {
+  Option<Command> prepareCommand;
+  Option<Command> cleanupCommand;
+
+  Option<Command> slaveRunTaskLabelDecoratorCommand;
+  Option<Command> slaveExecutorEnvironmentDecoratorCommand;
+  Option<Command> slaveRemoveExecutorHookCommand;
+
+  bool isDebugSet;
+};
+
+class ConfigurationParser
+{
+public:
+  static Configuration parse(const ::mesos::Parameters& parameters);
+};
+}
+}
+
+#endif // CONFIGURATION_PARSER_HPP

--- a/src/ConfigurationParser.hpp
+++ b/src/ConfigurationParser.hpp
@@ -9,6 +9,10 @@
 namespace criteo {
 namespace mesos {
 
+/**
+ * @brief The Configuration struct contains all elements the user
+ * can provide in the configuration.
+ */
 struct Configuration {
   Option<Command> prepareCommand;
   Option<Command> cleanupCommand;
@@ -17,12 +21,22 @@ struct Configuration {
   Option<Command> slaveExecutorEnvironmentDecoratorCommand;
   Option<Command> slaveRemoveExecutorHookCommand;
 
+  // this flag allows the user to enable debug mode.
   bool isDebugSet;
 };
 
+/**
+ * @brief The ConfigurationParser class parses the configuration KV provided by
+ * Mesos and produces a configuration object.
+ */
 class ConfigurationParser
 {
 public:
+  /**
+   * @brief parse the configuration provided by the user.
+   * @param parameters The parameters provided by Mesos.
+   * @return The configuration for each method.
+   */
   static Configuration parse(const ::mesos::Parameters& parameters);
 };
 }

--- a/src/Helpers.hpp
+++ b/src/Helpers.hpp
@@ -14,9 +14,7 @@ Result<Proto> jsonToProtobuf(const std::string& output) {
 
   auto outputJsonTry = JSON::parse(output);
   if (outputJsonTry.isError()) {
-    LOG(WARNING) << "Error when parsing string to JSON:"
-                 << outputJsonTry.error();
-    return Error("Malformed JSON");
+    return Error("Malformed JSON. " + outputJsonTry.error());
   }
 
   auto outputJson = outputJsonTry.get();
@@ -26,8 +24,7 @@ Result<Proto> jsonToProtobuf(const std::string& output) {
 
   auto proto = ::protobuf::parse<Proto>(outputJson);
   if (proto.isError()) {
-    LOG(WARNING) << "Error while converting JSON to protobuf: "
-                 << proto.error();
+    return Error("Error while converting JSON to protobuf. " + proto.error());
   }
   return proto;
 }

--- a/src/Logger.hpp
+++ b/src/Logger.hpp
@@ -1,0 +1,20 @@
+#ifndef __LOGGING_LOGGER_HPP__
+#define __LOGGING_LOGGER_HPP__
+
+#include <string>
+
+#define TASK_LOG(severity, metadata) \
+    LOG(severity) << "[TASK=" << metadata.taskId << ", METHOD=" << metadata.method << "] "
+
+namespace criteo {
+namespace mesos {
+namespace logging {
+struct Metadata {
+    std::string taskId;
+    std::string method;
+};
+}
+}
+}
+
+#endif

--- a/src/ModulesFactory.cpp
+++ b/src/ModulesFactory.cpp
@@ -1,6 +1,8 @@
 #include "ModulesFactory.hpp"
+
 #include "CommandHook.hpp"
 #include "CommandIsolator.hpp"
+#include "ConfigurationParser.hpp"
 
 namespace criteo {
 namespace mesos {
@@ -8,59 +10,16 @@ namespace mesos {
 using std::map;
 using std::string;
 
-/*
- * Parameters for hook
- */
-const string SLAVE_RUN_TASK_LABEL_DECORATOR_KEY =
-    "hook_slave_run_task_label_decorator";
-const string SLAVE_EXECUTOR_ENVIRONMENT_DECORATOR_KEY =
-    "hook_slave_executor_environment_decorator";
-const string SLAVE_REMOVE_EXECUTOR_KEY = "hook_slave_remove_executor_hook";
-
-/*
- * Parameters for isolator
- */
-const string PREPARE_KEY = "isolator_prepare";
-const string CLEANUP_KEY = "isolator_cleanup";
-
-const string DEBUG_KEY = "debug";
-
-map<string, string> toMap(const ::mesos::Parameters& parameters) {
-  map<string, string> kv;
-  foreach (const ::mesos::Parameter& parameter, parameters.parameter()) {
-    if (parameter.has_key() && parameter.has_value()) {
-      kv[parameter.key()] = parameter.value();
-    }
-  }
-  return kv;
-}
-
-string getOrEmpty(const map<string, string>& kv, const string& key) {
-  string command;
-  auto it = kv.find(key);
-  if (it != kv.end()) command = it->second;
-  return command;
-}
-
 ::mesos::Hook* createHook(const ::mesos::Parameters& parameters) {
-  map<string, string> p = toMap(parameters);
-  string runTaskLabelCommand =
-      getOrEmpty(p, SLAVE_RUN_TASK_LABEL_DECORATOR_KEY);
-  string executorEnvironmentCommand =
-      getOrEmpty(p, SLAVE_EXECUTOR_ENVIRONMENT_DECORATOR_KEY);
-  string removeExecutorCommand = getOrEmpty(p, SLAVE_REMOVE_EXECUTOR_KEY);
-  bool isDebugMode = getOrEmpty(p, DEBUG_KEY) == "true";
-  return new CommandHook(runTaskLabelCommand, executorEnvironmentCommand,
-                         removeExecutorCommand, isDebugMode);
+  Configuration cfg = ConfigurationParser::parse(parameters);
+  return new CommandHook(cfg.slaveRunTaskLabelDecoratorCommand, cfg.slaveExecutorEnvironmentDecoratorCommand,
+                         cfg.slaveRemoveExecutorHookCommand, cfg.isDebugSet);
 }
 
 ::mesos::slave::Isolator* createIsolator(
     const ::mesos::Parameters& parameters) {
-  map<string, string> p = toMap(parameters);
-  string prepareCommand = getOrEmpty(p, PREPARE_KEY);
-  string cleanupCommand = getOrEmpty(p, CLEANUP_KEY);
-  bool isDebugMode = getOrEmpty(p, DEBUG_KEY) == "true";
-  return new CommandIsolator(prepareCommand, cleanupCommand, isDebugMode);
+  Configuration cfg = ConfigurationParser::parse(parameters);
+  return new CommandIsolator(cfg.prepareCommand, cfg.cleanupCommand, cfg.isDebugSet);
 }
 }
 }

--- a/tests/CommandHookTest.cpp
+++ b/tests/CommandHookTest.cpp
@@ -16,9 +16,9 @@ class CommandHookTest : public ::testing::Test {
  public:
   void SetUp() {
     hook.reset(new CommandHook(
-        g_resourcesPath + "slaveRunTaskLabelDecorator.sh",
-        g_resourcesPath + "slaveExecutorEnvironmentDecorator.sh",
-        g_resourcesPath + "slaveRemoveExecutorHook.sh"));
+        Command(g_resourcesPath + "slaveRunTaskLabelDecorator.sh"),
+        Command(g_resourcesPath + "slaveExecutorEnvironmentDecorator.sh"),
+        Command(g_resourcesPath + "slaveRemoveExecutorHook.sh")));
     taskInfo.set_name("test_task");
     taskInfo.mutable_task_id()->set_value("1");
     taskInfo.mutable_slave_id()->set_value("2");
@@ -80,7 +80,7 @@ class UnexistingCommandHookTest : public CommandHookTest {
   void SetUp() {
     CommandHookTest::SetUp();
     hook.reset(
-        new CommandHook("unexisting.sh", "unexisting.sh", "unexisting.sh"));
+        new CommandHook(Command("unexisting.sh"), Command("unexisting.sh"), Command("unexisting.sh")));
   }
   std::unique_ptr<CommandHook> hook;
 };
@@ -105,9 +105,9 @@ class MalformedCommandHookTest : public CommandHookTest {
   void SetUp() {
     CommandHookTest::SetUp();
     hook.reset(new CommandHook(
-        g_resourcesPath + "slaveRunTaskLabelDecorator_malformed.sh",
-        g_resourcesPath + "slaveExecutorEnvironmentDecorator_malformed.sh",
-        g_resourcesPath + "slaveRemoveExecutorHook_malformed.sh"));
+        Command(g_resourcesPath + "slaveRunTaskLabelDecorator_malformed.sh"),
+        Command(g_resourcesPath + "slaveExecutorEnvironmentDecorator_malformed.sh"),
+        Command(g_resourcesPath + "slaveRemoveExecutorHook_malformed.sh")));
   }
   std::unique_ptr<CommandHook> hook;
 };
@@ -131,7 +131,7 @@ class EmptyCommandHookTest : public CommandHookTest {
  public:
   void SetUp() {
     CommandHookTest::SetUp();
-    hook.reset(new CommandHook("", "", ""));
+    hook.reset(new CommandHook(None(), None(), None()));
   }
   std::unique_ptr<CommandHook> hook;
 };
@@ -155,10 +155,10 @@ class IncorrectProtobufCommandHookTest : public CommandHookTest {
   void SetUp() {
     CommandHookTest::SetUp();
     hook.reset(new CommandHook(
-        g_resourcesPath + "slaveRunTaskLabelDecorator_incorrect_protobuf.sh",
-        g_resourcesPath +
-            "slaveExecutorEnvironmentDecorator_incorrect_protobuf.sh",
-        g_resourcesPath + "slaveRemoveExecutorHook_incorrect_protobuf.sh"));
+        Command(g_resourcesPath + "slaveRunTaskLabelDecorator_incorrect_protobuf.sh"),
+        Command(g_resourcesPath +
+            "slaveExecutorEnvironmentDecorator_incorrect_protobuf.sh"),
+        Command(g_resourcesPath + "slaveRemoveExecutorHook_incorrect_protobuf.sh")));
   }
   std::unique_ptr<CommandHook> hook;
 };

--- a/tests/CommandIsolatorTest.cpp
+++ b/tests/CommandIsolatorTest.cpp
@@ -17,8 +17,8 @@ class CommandIsolatorTest : public ::testing::Test {
 
  public:
   void SetUp() {
-    isolator.reset(new CommandIsolator(g_resourcesPath + "prepare.sh",
-                                       g_resourcesPath + "cleanup.sh"));
+    isolator.reset(new CommandIsolator(Command(g_resourcesPath + "prepare.sh"),
+                                       Command(g_resourcesPath + "cleanup.sh")));
     containerId.set_value("container_id");
 
     containerConfig.set_rootfs("/isolated_fs");
@@ -51,7 +51,7 @@ class UnexistingCommandIsolatorTest : public CommandIsolatorTest {
  public:
   void SetUp() {
     CommandIsolatorTest::SetUp();
-    isolator.reset(new CommandIsolator("unexisting.sh", "unexisting.sh"));
+    isolator.reset(new CommandIsolator(Command("unexisting.sh"), Command("unexisting.sh")));
   }
   std::unique_ptr<CommandIsolator> isolator;
 };
@@ -73,7 +73,7 @@ class MalformedCommandIsolatorTest : public CommandIsolatorTest {
   void SetUp() {
     CommandIsolatorTest::SetUp();
     isolator.reset(
-        new CommandIsolator(g_resourcesPath + "prepare_malformed.sh", ""));
+        new CommandIsolator(Command(g_resourcesPath + "prepare_malformed.sh"), None()));
   }
   std::unique_ptr<CommandIsolator> isolator;
 };
@@ -88,7 +88,7 @@ class EmptyCommandIsolatorTest : public CommandIsolatorTest {
  public:
   void SetUp() {
     CommandIsolatorTest::SetUp();
-    isolator.reset(new CommandIsolator("", ""));
+    isolator.reset(new CommandIsolator(None(), None()));
   }
   std::unique_ptr<CommandIsolator> isolator;
 };
@@ -112,7 +112,7 @@ class IncorrectProtobufCommandIsolatorTest : public CommandIsolatorTest {
   void SetUp() {
     CommandIsolatorTest::SetUp();
     isolator.reset(new CommandIsolator(
-        g_resourcesPath + "prepare_incorrect_protobuf.sh", ""));
+        Command(g_resourcesPath + "prepare_incorrect_protobuf.sh"), None()));
   }
   std::unique_ptr<CommandIsolator> isolator;
 };

--- a/tests/CommandRunnerTest.cpp
+++ b/tests/CommandRunnerTest.cpp
@@ -33,7 +33,7 @@ public:
 
 TEST_F(CommandRunnerTest, should_run_a_simple_sh_command_and_get_the_output) {
   Try<string> output =
-      m_commandRunner->run(g_resourcesPath + "pipe_input.sh", "HELLO", 10);
+      m_commandRunner->run(Command(g_resourcesPath + "pipe_input.sh", 10), "HELLO");
   EXPECT_EQ(output.get(), "HELLO > output");
 }
 
@@ -41,7 +41,7 @@ TEST_F(CommandRunnerTest, should_SIGTERM_inifinite_loop_command) {
   TEST_TIMEOUT_BEGIN
   logging::Metadata metadata = CommandRunnerTest::createMetada();
   Try<string> output =
-      CommandRunner(false, metadata).run(g_resourcesPath + "infinite_loop.sh", "", 1);
+      CommandRunner(false, metadata).run(Command(g_resourcesPath + "infinite_loop.sh", 1), "");
   EXPECT_ERROR(output);
   TEST_TIMEOUT_FAIL_END(2000)
 }
@@ -50,34 +50,35 @@ TEST_F(CommandRunnerTest, should_force_SIGKILL_inifinite_loop_command) {
   TEST_TIMEOUT_BEGIN
   logging::Metadata metadata = CommandRunnerTest::createMetada();
   Try<string> output =
-      CommandRunner(false, metadata).run(g_resourcesPath + "force_kill.sh", "", 1);
+      CommandRunner(false, metadata).run(Command(g_resourcesPath + "force_kill.sh", 1), "");
   EXPECT_ERROR(output);
   TEST_TIMEOUT_FAIL_END(3000)
 }
 
 TEST_F(CommandRunnerTest, should_not_crash_when_child_throws) {
-  EXPECT_ERROR(m_commandRunner->run(g_resourcesPath + "throw.sh", "", 10));
-  std::cout << m_commandRunner->run(g_resourcesPath + "throw.sh", "", 10).error();
-  EXPECT_ERROR_MESSAGE(m_commandRunner->run(g_resourcesPath + "throw.sh", "", 10), std::regex("Failed to successfully run the command .*throw.sh\", it failed with status 1"));
+  EXPECT_ERROR(m_commandRunner->run(Command(g_resourcesPath + "throw.sh", 10), ""));
+  std::cout << m_commandRunner->run(Command(g_resourcesPath + "throw.sh", 10), "").error();
+  EXPECT_ERROR_MESSAGE(m_commandRunner->run(Command(g_resourcesPath + "throw.sh", 10), ""),
+                       std::regex("Failed to successfully run the command .*throw.sh\", it failed with status 1"));
 }
 
 TEST_F(CommandRunnerTest, should_not_return_error_when_script_works) {
-  EXPECT_SOME(m_commandRunner->run(g_resourcesPath + "ok.sh", "", 10));
+  EXPECT_SOME(m_commandRunner->run(Command(g_resourcesPath + "ok.sh", 10), ""));
 }
 
 TEST_F(CommandRunnerTest, should_not_crash_when_executing_unexisting_command) {
-  EXPECT_NO_THROW({ m_commandRunner->run("blablabla", "", 10); });
+  EXPECT_NO_THROW({ m_commandRunner->run(Command("blablabla", 10), ""); });
 }
 
 TEST_F(CommandRunnerTest,
      should_return_an_error_when_executing_unexisting_command) {
-  Try<string> output = m_commandRunner->run("blablabla", "", 10);
+  Try<string> output = m_commandRunner->run(Command("blablabla", 10), "");
   EXPECT_ERROR(output);
 }
 
 TEST_F(CommandRunnerTest,
      should_return_an_error_when_executing_unexecutable_file) {
   Try<string> output =
-      m_commandRunner->run(g_resourcesPath + "unexecutable.sh", "", 10);
+      m_commandRunner->run(Command(g_resourcesPath + "unexecutable.sh", 10), "");
   EXPECT_ERROR(output);
 }

--- a/tests/ConfigurationParserTest.cpp
+++ b/tests/ConfigurationParserTest.cpp
@@ -1,0 +1,131 @@
+#include "ConfigurationParser.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace criteo::mesos;
+
+TEST(ConfigurationParserTest, should_create_configuration) {
+  ::mesos::Parameters parameters;
+  auto var = parameters.add_parameter();
+  var->set_key("hook_slave_run_task_label_decorator_command");
+  var->set_value("command_slave_run_task_label_decorator");
+  var = parameters.add_parameter();
+  var->set_key("hook_slave_run_task_label_decorator_timeout");
+  var->set_value("10");
+
+  var = parameters.add_parameter();
+  var->set_key("hook_slave_executor_environment_decorator_command");
+  var->set_value("command_slave_executor_environment_decorator");
+
+  var = parameters.add_parameter();
+  var->set_key("hook_slave_remove_executor_hook_command");
+  var->set_value("command_slave_remove_executor_hook");
+
+  var = parameters.add_parameter();
+  var->set_key("isolator_prepare_command");
+  var->set_value("command_prepare");
+  var = parameters.add_parameter();
+  var->set_key("isolator_prepare_timeout");
+  var->set_value("20");
+
+  var = parameters.add_parameter();
+  var->set_key("isolator_cleanup_command");
+  var->set_value("command_cleanup");
+
+  var = parameters.add_parameter();
+  var->set_key("debug");
+  var->set_value("true");
+
+  Configuration cfg = ConfigurationParser::parse(parameters);
+
+  EXPECT_EQ(cfg.slaveRunTaskLabelDecoratorCommand, Command("command_slave_run_task_label_decorator", 10));
+  EXPECT_EQ(cfg.slaveExecutorEnvironmentDecoratorCommand, Command("command_slave_executor_environment_decorator", 30));
+  EXPECT_EQ(cfg.slaveRemoveExecutorHookCommand, Command("command_slave_remove_executor_hook", 30));
+
+  EXPECT_EQ(cfg.prepareCommand, Command("command_prepare", 20));
+  EXPECT_EQ(cfg.cleanupCommand, Command("command_cleanup", 30));
+
+  EXPECT_TRUE(cfg.isDebugSet);
+}
+
+TEST(ConfigurationParserTest, should_create_configuration_with_optional_params) {
+  ::mesos::Parameters parameters;
+  auto var = parameters.add_parameter();
+
+  var->set_key("hook_slave_executor_environment_decorator_command");
+  var->set_value("command_slave_executor_environment_decorator");
+
+  var = parameters.add_parameter();
+  var->set_key("debug");
+  var->set_value("true");
+
+  Configuration cfg = ConfigurationParser::parse(parameters);
+
+  EXPECT_TRUE(cfg.slaveRunTaskLabelDecoratorCommand.isNone());
+  EXPECT_EQ(cfg.slaveExecutorEnvironmentDecoratorCommand, Command("command_slave_executor_environment_decorator", 30));
+  EXPECT_TRUE(cfg.slaveRemoveExecutorHookCommand.isNone());
+
+  EXPECT_TRUE(cfg.prepareCommand.isNone());
+  EXPECT_TRUE(cfg.cleanupCommand.isNone());
+
+  EXPECT_TRUE(cfg.isDebugSet);
+}
+
+TEST(ConfigurationParserTest, should_set_debug_only_with_true_value) {
+  ::mesos::Parameters parameters;
+  auto var = parameters.add_parameter();
+  var->set_key("debug");
+  var->set_value("true");
+
+  Configuration cfg = ConfigurationParser::parse(parameters);
+  EXPECT_TRUE(cfg.isDebugSet);
+
+  var->set_value("false");
+  cfg = ConfigurationParser::parse(parameters);
+  EXPECT_FALSE(cfg.isDebugSet);
+
+  var->set_value("anything123");
+  cfg = ConfigurationParser::parse(parameters);
+  EXPECT_FALSE(cfg.isDebugSet);
+}
+
+TEST(ConfigurationParserTest, should_throw_on_timeout_parsing_error) {
+  ::mesos::Parameters parameters;
+  auto var = parameters.add_parameter();
+  var->set_key("hook_slave_executor_environment_decorator_command");
+  var->set_value("command_slave_executor_environment_decorator");
+
+  var = parameters.add_parameter();
+  var->set_key("hook_slave_executor_environment_decorator_timeout");
+  var->set_value("abc");
+
+  try {
+    Configuration cfg = ConfigurationParser::parse(parameters);
+    FAIL() << "Expected std::invalid_argument.";
+  } catch (const std::invalid_argument&) {
+    SUCCEED() << "Thrown invalid_argument.";
+  } catch (...) {
+    FAIL() << "Expected std::invalid_argument.";
+  }
+}
+
+TEST(ConfigurationParserTest, should_throw_on_timeout_out_of_range) {
+  ::mesos::Parameters parameters;
+  auto var = parameters.add_parameter();
+  var->set_key("hook_slave_executor_environment_decorator_command");
+  var->set_value("command_slave_executor_environment_decorator");
+
+  var = parameters.add_parameter();
+  var->set_key("hook_slave_executor_environment_decorator_timeout");
+  var->set_value("10000000000000000000000000000000000000000000000000000");
+
+  try {
+    Configuration cfg = ConfigurationParser::parse(parameters);
+    FAIL() << "Expected std::out_of_range.";
+  } catch (const std::out_of_range&) {
+    SUCCEED() << "Thrown out_of_range.";
+  } catch (...) {
+    FAIL() << "Expected std::out_of_range.";
+  }
+}
+

--- a/tests/ModulesFactoryTest.cpp
+++ b/tests/ModulesFactoryTest.cpp
@@ -11,41 +11,41 @@ using namespace criteo::mesos;
 TEST(ModulesFactoryTest, should_create_hook_with_correct_parameters) {
   ::mesos::Parameters parameters;
   auto var = parameters.add_parameter();
-  var->set_key("hook_slave_run_task_label_decorator");
+  var->set_key("hook_slave_run_task_label_decorator_command");
   var->set_value("command_slave_run_task_label_decorator");
 
   var = parameters.add_parameter();
-  var->set_key("hook_slave_executor_environment_decorator");
+  var->set_key("hook_slave_executor_environment_decorator_command");
   var->set_value("command_slave_executor_environment_decorator");
 
   var = parameters.add_parameter();
-  var->set_key("hook_slave_remove_executor_hook");
+  var->set_key("hook_slave_remove_executor_hook_command");
   var->set_value("command_slave_remove_executor_hook");
 
   std::unique_ptr<CommandHook> hook(
       dynamic_cast<CommandHook*>(createHook(parameters)));
 
-  ASSERT_EQ(hook->runTaskLabelCommand(),
-            "command_slave_run_task_label_decorator");
-  ASSERT_EQ(hook->executorEnvironmentCommand(),
-            "command_slave_executor_environment_decorator");
-  ASSERT_EQ(hook->removeExecutorCommand(),
-            "command_slave_remove_executor_hook");
+  ASSERT_EQ(hook->runTaskLabelCommand().get(),
+            Command("command_slave_run_task_label_decorator", 30));
+  ASSERT_EQ(hook->executorEnvironmentCommand().get(),
+            Command("command_slave_executor_environment_decorator", 30));
+  ASSERT_EQ(hook->removeExecutorCommand().get(),
+            Command("command_slave_remove_executor_hook", 30));
 }
 
 TEST(ModulesFactoryTest, should_create_hook_with_empty_parameters) {
   ::mesos::Parameters parameters;
   auto var = parameters.add_parameter();
-  var->set_key("hook_slave_executor_environment_decorator");
+  var->set_key("hook_slave_executor_environment_decorator_command");
   var->set_value("command_slave_executor_environment_decorator");
 
   std::unique_ptr<CommandHook> hook(
       dynamic_cast<CommandHook*>(createHook(parameters)));
 
-  ASSERT_TRUE(hook->runTaskLabelCommand().empty());
-  ASSERT_EQ(hook->executorEnvironmentCommand(),
-            "command_slave_executor_environment_decorator");
-  ASSERT_TRUE(hook->removeExecutorCommand().empty());
+  ASSERT_TRUE(hook->runTaskLabelCommand().isNone());
+  ASSERT_EQ(hook->executorEnvironmentCommand().get(),
+            Command("command_slave_executor_environment_decorator", 30));
+  ASSERT_TRUE(hook->removeExecutorCommand().isNone());
 }
 
 // ***************************************
@@ -54,29 +54,29 @@ TEST(ModulesFactoryTest, should_create_hook_with_empty_parameters) {
 TEST(ModulesFactoryTest, should_create_isolator_with_correct_parameters) {
   ::mesos::Parameters parameters;
   auto var = parameters.add_parameter();
-  var->set_key("isolator_prepare");
+  var->set_key("isolator_prepare_command");
   var->set_value("command_prepare");
 
   var = parameters.add_parameter();
-  var->set_key("isolator_cleanup");
+  var->set_key("isolator_cleanup_command");
   var->set_value("command_cleanup");
 
   std::unique_ptr<CommandIsolator> isolator(
       dynamic_cast<CommandIsolator*>(createIsolator(parameters)));
 
-  ASSERT_EQ(isolator->prepareCommand(), "command_prepare");
-  ASSERT_EQ(isolator->cleanupCommand(), "command_cleanup");
+  ASSERT_EQ(isolator->prepareCommand().get(), Command("command_prepare", 30));
+  ASSERT_EQ(isolator->cleanupCommand().get(), Command("command_cleanup", 30));
 }
 
 TEST(ModulesFactoryTest, should_create_isolator_with_empty_parameters) {
   ::mesos::Parameters parameters;
   auto var = parameters.add_parameter();
-  var->set_key("isolator_prepare");
+  var->set_key("isolator_prepare_command");
   var->set_value("command_prepare");
 
   std::unique_ptr<CommandIsolator> isolator(
       dynamic_cast<CommandIsolator*>(createIsolator(parameters)));
 
-  ASSERT_EQ(isolator->prepareCommand(), "command_prepare");
-  ASSERT_TRUE(isolator->cleanupCommand().empty());
+  ASSERT_EQ(isolator->prepareCommand().get(), Command("command_prepare", 30));
+  ASSERT_TRUE(isolator->cleanupCommand().isNone());
 }


### PR DESCRIPTION
Up to now blocked command were terminated after a non-configurable amount of time. This PR introduces timeouts in the configuration file so that one can define them independently for each command.