### PR TITLE
Add support for isolator watch callback

### DIFF
--- a/src/CommandIsolator.cpp
+++ b/src/CommandIsolator.cpp
@@ -3,6 +3,7 @@
 #include "Helpers.hpp"
 #include "Logger.hpp"
 
+#include <glog/logging.h>
 #include <process/dispatch.hpp>
 #include <process/process.hpp>
 
@@ -14,17 +15,22 @@ using std::string;
 using ::mesos::ContainerID;
 using ::mesos::slave::ContainerConfig;
 using ::mesos::slave::ContainerLaunchInfo;
+using ::mesos::slave::ContainerLimitation;
 
 using process::Failure;
 
 class CommandIsolatorProcess : public process::Process<CommandIsolatorProcess> {
  public:
   CommandIsolatorProcess(const Option<Command>& prepareCommand,
+                         const Option<Command>& watchCommand,
                          const Option<Command>& cleanupCommand,
                          bool isDebugMode);
 
   virtual process::Future<Option<ContainerLaunchInfo>> prepare(
       const ContainerID& containerId, const ContainerConfig& containerConfig);
+
+  virtual process::Future<ContainerLimitation> watch(
+      const ContainerID& containerId);
 
   virtual process::Future<Nothing> cleanup(const ContainerID& containerId);
 
@@ -38,14 +44,16 @@ class CommandIsolatorProcess : public process::Process<CommandIsolatorProcess> {
 
  private:
   Option<Command> m_prepareCommand;
+  Option<Command> m_watchCommand;
   Option<Command> m_cleanupCommand;
   bool m_isDebugMode;
 };
 
 CommandIsolatorProcess::CommandIsolatorProcess(
-    const Option<Command>& prepareCommand,
+    const Option<Command>& prepareCommand, const Option<Command>& watchCommand,
     const Option<Command>& cleanupCommand, bool isDebugMode)
     : m_prepareCommand(prepareCommand),
+      m_watchCommand(watchCommand),
       m_cleanupCommand(cleanupCommand),
       m_isDebugMode(isDebugMode) {}
 
@@ -82,6 +90,40 @@ process::Future<Option<ContainerLaunchInfo>> CommandIsolatorProcess::prepare(
   return containerLaunchInfo.get();
 }
 
+process::Future<ContainerLimitation> CommandIsolatorProcess::watch(
+    const ContainerID& containerId) {
+  if (m_watchCommand.isNone()) {
+    return process::Future<ContainerLimitation>();
+  }
+
+  logging::Metadata metadata = {containerId.value(), "watch"};
+
+  JSON::Object inputsJson;
+  inputsJson.values["container_id"] = JSON::protobuf(containerId);
+
+  Try<string> output = CommandRunner(m_isDebugMode, metadata)
+                           .run(m_watchCommand.get(), stringify(inputsJson));
+
+  if (output.isError()) {
+    LOG(WARNING) << "Unable to parse output: " << output.error();
+    return process::Future<ContainerLimitation>();
+  }
+
+  if (output->empty()) {
+    return process::Future<ContainerLimitation>();
+  }
+
+  Result<ContainerLimitation> containerLimitation =
+      jsonToProtobuf<ContainerLimitation>(output.get());
+
+  if (containerLimitation.isError()) {
+    LOG(WARNING) << "Unable to deserialize ContainerLimitation: "
+                 << containerLimitation.error();
+    return process::Future<ContainerLimitation>();
+  }
+  return containerLimitation.get();
+}
+
 process::Future<Nothing> CommandIsolatorProcess::cleanup(
     const ContainerID& containerId) {
   if (m_cleanupCommand.isNone()) {
@@ -104,10 +146,11 @@ process::Future<Nothing> CommandIsolatorProcess::cleanup(
 }
 
 CommandIsolator::CommandIsolator(const Option<Command>& prepareCommand,
+                                 const Option<Command>& watchCommand,
                                  const Option<Command>& cleanupCommand,
                                  bool isDebugMode)
-    : m_process(new CommandIsolatorProcess(prepareCommand, cleanupCommand,
-                                           isDebugMode)) {
+    : m_process(new CommandIsolatorProcess(prepareCommand, watchCommand,
+                                           cleanupCommand, isDebugMode)) {
   spawn(m_process);
 }
 
@@ -123,6 +166,11 @@ process::Future<Option<ContainerLaunchInfo>> CommandIsolator::prepare(
     const ContainerID& containerId, const ContainerConfig& containerConfig) {
   return dispatch(m_process, &CommandIsolatorProcess::prepare, containerId,
                   containerConfig);
+}
+
+process::Future<ContainerLimitation> CommandIsolator::watch(
+    const ContainerID& containerId) {
+  return dispatch(m_process, &CommandIsolatorProcess::watch, containerId);
 }
 
 process::Future<Nothing> CommandIsolator::cleanup(

--- a/src/CommandIsolator.hpp
+++ b/src/CommandIsolator.hpp
@@ -39,6 +39,7 @@ class CommandIsolator : public ::mesos::slave::Isolator {
    *   otherwise logs nothing
    */
   explicit CommandIsolator(const Option<Command>& prepareCommand,
+                           const Option<Command>& watchCommand,
                            const Option<Command>& cleanupCommand,
                            bool isDebugMode = false);
 
@@ -69,6 +70,12 @@ class CommandIsolator : public ::mesos::slave::Isolator {
    * @return A future resolving nothing if successful.
    */
   virtual process::Future<Nothing> cleanup(
+      const ::mesos::ContainerID& containerId);
+
+  // Watch the containerized executor and report if any resource
+  // constraint impacts the container, e.g., the kernel killing some
+  // processes.
+  virtual process::Future<::mesos::slave::ContainerLimitation> watch(
       const ::mesos::ContainerID& containerId);
 
   /**

--- a/src/CommandRunner.cpp
+++ b/src/CommandRunner.cpp
@@ -249,23 +249,28 @@ Try<Nothing> runCommandWithTimeout(const std::string& command,
     return false;
   };
 
-  milliseconds tickPeriod(100);
-  Timer t1(tickPeriod, milliseconds(timeoutInSeconds * 1000));
-  t1.run(waitProcess);
+  // Hack to support command without timeout
+  // TODO: to remove once the CommandIsolator::watch implementation has been
+  // changed
+  if (timeoutInSeconds > 0) {
+    milliseconds tickPeriod(100);
+    Timer t1(tickPeriod, milliseconds(timeoutInSeconds * 1000));
+    t1.run(waitProcess);
 
-  if (t1.hasTimedOut() && !forceKillRequired) {
-    TASK_LOG(WARNING, loggingMetadata)
-        << "External command took too long to exit. "
-        << "Sending SIGTERM...";
-    if (kill(pid, SIGTERM) == -1) {
-      TASK_LOG(ERROR, loggingMetadata) << "Failed to send SIGTERM: "
-                                       << strerror(errno);
-      forceKillRequired = true;
-    } else {
-      Timer t(tickPeriod, milliseconds(1000));
-      t.run(waitProcess);
-      if (t.hasTimedOut()) {
+    if (t1.hasTimedOut() && !forceKillRequired) {
+      TASK_LOG(WARNING, loggingMetadata)
+          << "External command took too long to exit. "
+          << "Sending SIGTERM...";
+      if (kill(pid, SIGTERM) == -1) {
+        TASK_LOG(ERROR, loggingMetadata)
+            << "Failed to send SIGTERM: " << strerror(errno);
         forceKillRequired = true;
+      } else {
+        Timer t(tickPeriod, milliseconds(1000));
+        t.run(waitProcess);
+        if (t.hasTimedOut()) {
+          forceKillRequired = true;
+        }
       }
     }
   }
@@ -274,8 +279,8 @@ Try<Nothing> runCommandWithTimeout(const std::string& command,
     TASK_LOG(WARNING, loggingMetadata)
         << "External command is still running. Sending SIGKILL...";
     if (kill(pid, SIGKILL) == -1) {
-      TASK_LOG(ERROR, loggingMetadata) << "Failed to kill the command: "
-                                       << strerror(errno);
+      TASK_LOG(ERROR, loggingMetadata)
+          << "Failed to kill the command: " << strerror(errno);
       return Error("Command \"" + command +
                    "\" took too long to execute and SIGKILL failed.");
     } else {
@@ -326,9 +331,9 @@ Try<string> CommandRunner::run(const Command& command,
           << command.timeout() << "s) " << inputFile.filepath() << " "
           << outputFile.filepath() << " " << errorFile.filepath();
     } else {
-      TASK_LOG(INFO, m_loggingMetadata) << "Calling command: \""
-                                        << command.command() << "\" ("
-                                        << command.timeout() << "s)";
+      TASK_LOG(INFO, m_loggingMetadata)
+          << "Calling command: \"" << command.command() << "\" ("
+          << command.timeout() << "s)";
     }
 
     vector<string> args;

--- a/src/ConfigurationParser.cpp
+++ b/src/ConfigurationParser.cpp
@@ -18,6 +18,7 @@ const string SLAVE_REMOVE_EXECUTOR_KEY = "hook_slave_remove_executor_hook";
 
 // Isolator commands.
 const string PREPARE_KEY = "isolator_prepare";
+const string WATCH_KEY = "isolator_watch";
 const string CLEANUP_KEY = "isolator_cleanup";
 
 // Additional parameters.
@@ -70,6 +71,7 @@ Configuration ConfigurationParser::parse(
       extractCommand(p, SLAVE_RUN_TASK_LABEL_DECORATOR_KEY);
 
   configuration.prepareCommand = extractCommand(p, PREPARE_KEY);
+  configuration.watchCommand = extractCommand(p, WATCH_KEY);
   configuration.cleanupCommand = extractCommand(p, CLEANUP_KEY);
 
   configuration.isDebugSet = getOrEmpty(p, DEBUG_KEY) == "true";

--- a/src/ConfigurationParser.hpp
+++ b/src/ConfigurationParser.hpp
@@ -15,6 +15,7 @@ namespace mesos {
  */
 struct Configuration {
   Option<Command> prepareCommand;
+  Option<Command> watchCommand;
   Option<Command> cleanupCommand;
 
   Option<Command> slaveRunTaskLabelDecoratorCommand;

--- a/src/ModulesFactory.cpp
+++ b/src/ModulesFactory.cpp
@@ -20,8 +20,8 @@ using std::string;
 ::mesos::slave::Isolator* createIsolator(
     const ::mesos::Parameters& parameters) {
   Configuration cfg = ConfigurationParser::parse(parameters);
-  return new CommandIsolator(cfg.prepareCommand, cfg.cleanupCommand,
-                             cfg.isDebugSet);
+  return new CommandIsolator(cfg.prepareCommand, cfg.watchCommand,
+                             cfg.cleanupCommand, cfg.isDebugSet);
 }
 }  // namespace mesos
 }  // namespace criteo

--- a/tests/CommandIsolatorTest.cpp
+++ b/tests/CommandIsolatorTest.cpp
@@ -164,19 +164,3 @@ TEST_F(IncorrectProtobufCommandIsolatorTest,
   auto future = isolator->watch(containerId);
   AWAIT_ASSERT_ABANDONED(future);
 }
-
-class EmptyOutputCommandIsolatorTest : public CommandIsolatorTest {
- public:
-  void SetUp() {
-    CommandIsolatorTest::SetUp();
-    isolator.reset(new CommandIsolator(
-        None(), Command(g_resourcesPath + "watch_empty.sh"), None()));
-  }
-  std::unique_ptr<CommandIsolator> isolator;
-};
-
-TEST_F(EmptyOutputCommandIsolatorTest,
-       should_run_watch_command_and_do_nothing_on_empty_output) {
-  auto future = isolator->watch(containerId);
-  AWAIT_ASSERT_ABANDONED(future);
-}

--- a/tests/CommandIsolatorTest.cpp
+++ b/tests/CommandIsolatorTest.cpp
@@ -164,3 +164,19 @@ TEST_F(IncorrectProtobufCommandIsolatorTest,
   auto future = isolator->watch(containerId);
   AWAIT_ASSERT_ABANDONED(future);
 }
+
+class EmptyOutputCommandIsolatorTest : public CommandIsolatorTest {
+ public:
+  void SetUp() {
+    CommandIsolatorTest::SetUp();
+    isolator.reset(new CommandIsolator(
+        None(), Command(g_resourcesPath + "watch_empty.sh"), None()));
+  }
+  std::unique_ptr<CommandIsolator> isolator;
+};
+
+TEST_F(EmptyOutputCommandIsolatorTest,
+       should_run_watch_command_and_do_nothing_on_empty_output) {
+  auto future = isolator->watch(containerId);
+  AWAIT_ASSERT_ABANDONED(future);
+}

--- a/tests/scripts/watch.sh
+++ b/tests/scripts/watch.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo '{"resources":[{"name":"toto","type":"SCALAR","scalar":{"value":1}}],"message":"too much toto","reason":"REASON_CONTAINER_LIMITATION"}' >$2

--- a/tests/scripts/watch_incorrect_protobuf.sh
+++ b/tests/scripts/watch_incorrect_protobuf.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo '"does not match ContainerLimitation"' >$2

--- a/tests/scripts/watch_malformed.sh
+++ b/tests/scripts/watch_malformed.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo 'MALFORMED' >$2


### PR DESCRIPTION
This PR adds support of the `watch` callback for the CommandIsolator.
This callback differs from `prepare` and `cleanup` in that it is supposed to be long running, and return only if the container has reached a certain limit and is to be killed. It can also returns with an abandoned future, in which case the container will not be killed (with the drawback that the `watch` callback will never be called again during the lifecycle of the container).

This implementation is experimental, so not adding the documentation to README for now.