### PR TITLE
Remove undefined clang-format make rule references

### DIFF
--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -11,15 +11,6 @@ cd build
 cmake ..
 
 export PATH=$PATH:/opt/llvm-3.8.0/bin
-make clang-format
-
-updated_files_count=`git diff --name-only | wc -l`
-
-if [ "$updated_files_count" -ne "0" ];
-then
-  echo "[FAILED] Please run 'make clang-format' and commit the changes."
-  exit 1
-fi
 
 make
 make check


### PR DESCRIPTION
This target does not exist. With current code, we have to commit every
changes before running tests (otherwise it fails with unrelated error)

Change-Id: Iff2d01d8cd71ad5b587ea02d882ce11aa99b2917