### PR TITLE
Support ResourceStatistics extract with usage 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ find_program(
   )
 
 if(NOT CLANG_FORMAT_EXE)
-  message(STATUS "clang-format not found.")
+  message(STATUS "clang-format not installed.")
 else()
   message(STATUS "clang-format found: ${CLANG_FORMAT_EXE}")
   add_custom_target(

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ ENV MESOS_BUILD_DIR=/src/mesos/build
 
 ADD scripts/llvm-3.8.0.repo /etc/yum.repos.d/
 RUN yum install -y cmake clang-3.8.0
-
+ENV PATH="${PATH}:/opt/llvm-3.8.0/bin"

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -9,16 +9,15 @@ mkdir build
 cd build
 
 cmake ..
-
-export PATH=$PATH:/opt/llvm-3.8.0/bin
 make clang-format
 
 updated_files_count=`git diff --name-only | wc -l`
 
-if [ "$updated_files_count" -ne "0" ];
-then
-  echo "[FAILED] Please run 'make clang-format' and commit the changes."
-  exit 1
+if [ -n "$TRAVIS" ]; then
+  if [ "$updated_files_count" -ne "0" ]; then
+    echo "[FAILED] Please run 'make clang-format' and commit the changes."
+    exit 1
+  fi
 fi
 
 make

--- a/src/CommandIsolator.hpp
+++ b/src/CommandIsolator.hpp
@@ -32,15 +32,20 @@ class CommandIsolator : public ::mesos::slave::Isolator {
    * isolation primitive will not be treated.
    *
    * @param prepareCommand The command to execute when `prepare` event is
-   *   is triggered for a given container.
+   *   triggered for a given container.
    * @param cleanupCommand The command to execute when `cleanup` event is
-   *   is triggered for a given container.
+   *   triggered for a given container.
+   * @param watchCommand The command to execute when `watch` event is
+   *   triggered  for a given container. This command will be frequently called
+   * @param usageCommand The command to execute when `usage` event is triggered
+   *   for a given container. This command will be frequently called
    * @param isDebugMode If true, logs inputs and outputs of the commands,
    *   otherwise logs nothing
    */
   explicit CommandIsolator(const Option<Command>& prepareCommand,
                            const Option<Command>& watchCommand,
                            const Option<Command>& cleanupCommand,
+                           const Option<Command>& usageCommand,
                            bool isDebugMode = false);
 
   /**
@@ -87,6 +92,10 @@ class CommandIsolator : public ::mesos::slave::Isolator {
    * Get cleanup command.
    */
   const Option<Command>& cleanupCommand() const;
+
+  // Get resource usage of a given container
+  virtual process::Future<::mesos::ResourceStatistics> usage(
+      const ::mesos::ContainerID& containerId);
 
  private:
   CommandIsolatorProcess* m_process;

--- a/src/ConfigurationParser.cpp
+++ b/src/ConfigurationParser.cpp
@@ -20,6 +20,7 @@ const string SLAVE_REMOVE_EXECUTOR_KEY = "hook_slave_remove_executor_hook";
 const string PREPARE_KEY = "isolator_prepare";
 const string WATCH_KEY = "isolator_watch";
 const string CLEANUP_KEY = "isolator_cleanup";
+const string USAGE_KEY = "isolator_usage";
 
 // Additional parameters.
 const string DEBUG_KEY = "debug";  // enable debug mode.
@@ -73,6 +74,7 @@ Configuration ConfigurationParser::parse(
   configuration.prepareCommand = extractCommand(p, PREPARE_KEY);
   configuration.watchCommand = extractCommand(p, WATCH_KEY);
   configuration.cleanupCommand = extractCommand(p, CLEANUP_KEY);
+  configuration.usageCommand = extractCommand(p, USAGE_KEY);
 
   configuration.isDebugSet = getOrEmpty(p, DEBUG_KEY) == "true";
   return configuration;

--- a/src/ConfigurationParser.hpp
+++ b/src/ConfigurationParser.hpp
@@ -17,6 +17,7 @@ struct Configuration {
   Option<Command> prepareCommand;
   Option<Command> watchCommand;
   Option<Command> cleanupCommand;
+  Option<Command> usageCommand;
 
   Option<Command> slaveRunTaskLabelDecoratorCommand;
   Option<Command> slaveExecutorEnvironmentDecoratorCommand;

--- a/src/ModulesFactory.cpp
+++ b/src/ModulesFactory.cpp
@@ -21,7 +21,8 @@ using std::string;
     const ::mesos::Parameters& parameters) {
   Configuration cfg = ConfigurationParser::parse(parameters);
   return new CommandIsolator(cfg.prepareCommand, cfg.watchCommand,
-                             cfg.cleanupCommand, cfg.isDebugSet);
+                             cfg.cleanupCommand, cfg.usageCommand,
+                             cfg.isDebugSet);
 }
 }  // namespace mesos
 }  // namespace criteo

--- a/tests/scripts/usage.sh
+++ b/tests/scripts/usage.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo '{"timestamp": 12345, "net_snmp_statistics": {
+"tcp_stats": { "CurrEstab": 5}
+}}' >$2

--- a/tests/scripts/usage_empty.sh
+++ b/tests/scripts/usage_empty.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+# do nothing here, so output file remains empty

--- a/tests/scripts/usage_incorrect_protobuf.sh
+++ b/tests/scripts/usage_incorrect_protobuf.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo '"does not match ResourceStatistics"' >$2

--- a/tests/scripts/usage_malformed.sh
+++ b/tests/scripts/usage_malformed.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo 'MALFORMED' >$2


### PR DESCRIPTION
~This is in request-for-comment rigth now I've not tested this on a real cluster.~

Now tested, it works correctly and metrics are exposed on localhost:5051/monitor/statistics endpoints