### PR TITLE
Fix temp files removal bug

### DIFF
--- a/src/CommandRunner.cpp
+++ b/src/CommandRunner.cpp
@@ -214,7 +214,11 @@ Future<Try<string>> CommandRunner::asyncRun(const Command& command,
           }
           return os::read(outputFile.filepath());
         })
-        .onAny([=](Future<Try<string>> output) -> Future<Try<string>> {
+        .onAny([=, loggingMetadata = m_loggingMetadata](
+                   Future<Try<string>> output) -> Future<Try<string>> {
+          TASK_LOG(INFO, loggingMetadata)
+              << "Removing temp files " << inputFile.filepath() << " "
+              << outputFile.filepath() << " " << errorFile.filepath();
           os::rm(inputFile.filepath());
           os::rm(outputFile.filepath());
           os::rm(errorFile.filepath());

--- a/src/CommandRunner.cpp
+++ b/src/CommandRunner.cpp
@@ -37,6 +37,7 @@
 namespace criteo {
 namespace mesos {
 
+using std::ostream;
 using std::string;
 using std::vector;
 using namespace std::chrono;
@@ -82,6 +83,11 @@ class TemporaryFile {
   }
 
   inline const std::string& filepath() const { return m_filepath; }
+
+  friend ostream& operator<<(ostream& out, const TemporaryFile& temp_file) {
+    out << temp_file.m_filepath;
+    return out;
+  }
 
  private:
   std::string m_filepath;
@@ -217,8 +223,8 @@ Future<Try<string>> CommandRunner::asyncRun(const Command& command,
         .onAny([=, loggingMetadata = m_loggingMetadata](
                    Future<Try<string>> output) -> Future<Try<string>> {
           TASK_LOG(INFO, loggingMetadata)
-              << "Removing temp files " << inputFile.filepath() << " "
-              << outputFile.filepath() << " " << errorFile.filepath();
+              << "Removing temp files " << inputFile << " " << outputFile << " "
+              << errorFile;
           os::rm(inputFile.filepath());
           os::rm(outputFile.filepath());
           os::rm(errorFile.filepath());

--- a/src/CommandRunner.cpp
+++ b/src/CommandRunner.cpp
@@ -214,7 +214,7 @@ Future<Try<string>> CommandRunner::asyncRun(const Command& command,
           }
           return os::read(outputFile.filepath());
         })
-        .onAny([&](Future<Try<string>> output) -> Future<Try<string>> {
+        .onAny([=](Future<Try<string>> output) -> Future<Try<string>> {
           os::rm(inputFile.filepath());
           os::rm(outputFile.filepath());
           os::rm(errorFile.filepath());


### PR DESCRIPTION
No surprise, the regression was hit because we don't have a unit test to check that the temporary files are effectively removed. Unfortunately implementing such a test is non trivial and require to rework a bit how temporary files objects are defined and use, so putting since as FAR for now.