### PR TITLE
Define several instances of modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Then, restart the Mesos slaves to complete the installation and have a
 look at the logs to confirm that your scripts are called when some of your
 configured events are triggered.
 
+Note: com_criteo_mesos_CommandIsolator2, com_criteo_mesos_CommandIsolator3, ... are also defined to allow to have several distinct isolators.
+
 ## Build Instructions
 
 ```shell

--- a/src/ModulesFactory.cpp
+++ b/src/ModulesFactory.cpp
@@ -30,9 +30,37 @@ using std::string;
 mesos::modules::Module<::mesos::Hook> com_criteo_mesos_CommandHook(
     MESOS_MODULE_API_VERSION, MESOS_VERSION, "Criteo Mesos", "mesos@criteo.com",
     "Command hook module", nullptr, criteo::mesos::createHook);
+// Mesos does not accept to instanciate several instances of the same module
+// so we create multiple instances named com_criteo_mesos_CommandHook2,3,..
+// to allow user to have separated isolator based on CommandHook
+#define CRITEO_HOOK(INSTANCE)                                      \
+  mesos::modules::Module<::mesos::Hook>                            \
+      com_criteo_mesos_CommandHook##INSTANCE(                      \
+          MESOS_MODULE_API_VERSION, MESOS_VERSION, "Criteo Mesos", \
+          "mesos@criteo.com", "Command hook module", nullptr,      \
+          criteo::mesos::createHook);
+
+CRITEO_HOOK(2)
+CRITEO_HOOK(3)
+CRITEO_HOOK(4)
+CRITEO_HOOK(5)
 
 mesos::modules::Module<::mesos::slave::Isolator>
     com_criteo_mesos_CommandIsolator(MESOS_MODULE_API_VERSION, MESOS_VERSION,
                                      "Criteo Mesos", "mesos@criteo.com",
                                      "Command isolator module", nullptr,
                                      criteo::mesos::createIsolator);
+// Mesos does not accept to instanciate several instances of the same module
+// so we create multiple instances named com_criteo_mesos_CommandIsolator2,3,..
+// to allow user to have separated isolator based on CommandIsolator
+#define CRITEO_ISOLATOR(INSTANCE)                                  \
+  mesos::modules::Module<::mesos::slave::Isolator>                 \
+      com_criteo_mesos_CommandIsolator##INSTANCE(                  \
+          MESOS_MODULE_API_VERSION, MESOS_VERSION, "Criteo Mesos", \
+          "mesos@criteo.com", "Command isolator module", nullptr,  \
+          criteo::mesos::createIsolator);
+
+CRITEO_ISOLATOR(2)
+CRITEO_ISOLATOR(3)
+CRITEO_ISOLATOR(4)
+CRITEO_ISOLATOR(5)


### PR DESCRIPTION
Mesos does not accept to instanciate several instances of the same
module (likely because there is no generic module like ours).
Yet users (criteo included) might want to have several "isolators" or
"hooks" having different features.

Our workaround so far was to create a wrapper script that would call the
others but it is quite unpractical introduce coupling.

This patch creates a fixed number of isolator/hooks that can be used.
It is quite easy to increase their number.

Change-Id: I27e92ed62ca751d01a5b18f04760534bd3985cd4