### PR TITLE
Add mergify configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,16 @@
+pull_request_rules:
+  - name: remove outdated reviews
+    conditions:
+      - base=master
+    actions:
+      dismiss_reviews: {}
+  - name: automatic merge on CI success and review
+    conditions:
+      - status-success=continuous-integration/travis-ci/pr
+      - "#approved-reviews-by>=1"
+      - base=master
+      - "#changes-requested-reviews-by=0"
+      - label=ready-to-submit
+    actions:
+      merge:
+        method: merge


### PR DESCRIPTION
This configuration aims to reproduce criteo rules:
- every new PR version has to be reviewed (as a new gerrit patchset)
- PR are merged if ready-to-submit + HumanCodeReview + CI verification

Change-Id: I26640ceb946316fc54eabfd362186eff08dcdece