### PR TITLE
Properly display futures status

### DIFF
--- a/src/CommandIsolator.cpp
+++ b/src/CommandIsolator.cpp
@@ -49,7 +49,8 @@ class CommandIsolatorProcess : public process::Process<CommandIsolatorProcess> {
   }
 
  private:
-  inline static ::mesos::ResourceStatistics emptyStats(double timestamp = Clock::now().secs()) {
+  inline static ::mesos::ResourceStatistics emptyStats(
+      double timestamp = Clock::now().secs()) {
     ::mesos::ResourceStatistics stats;
     stats.set_timestamp(timestamp);
     return stats;
@@ -152,30 +153,32 @@ process::Future<::mesos::ResourceStatistics> CommandIsolatorProcess::usage(
 
   return CommandRunner(m_isDebugMode, metadata)
       .asyncRun(m_usageCommand.get(), stringify(inputsJson))
-      .then([now=now](Try<string> output) -> Future<::mesos::ResourceStatistics> {
-        if (output.isError()) {
-          LOG(WARNING) << "Unable to parse output: " << output.error();
-          return emptyStats(now);
-        }
-        if (output->empty()) {
-          LOG(WARNING) << "Output is empty";
-          return emptyStats(now);
-        }
-        Result<::mesos::ResourceStatistics> resourceStatistics =
-            jsonToProtobuf<::mesos::ResourceStatistics>(output.get());
+      .then([now = now](Try<string> output)
+                ->Future<::mesos::ResourceStatistics> {
+                  if (output.isError()) {
+                    LOG(WARNING) << "Unable to parse output: "
+                                 << output.error();
+                    return emptyStats(now);
+                  }
+                  if (output->empty()) {
+                    LOG(WARNING) << "Output is empty";
+                    return emptyStats(now);
+                  }
+                  Result<::mesos::ResourceStatistics> resourceStatistics =
+                      jsonToProtobuf<::mesos::ResourceStatistics>(output.get());
 
-        if (resourceStatistics.isError()) {
-          LOG(WARNING) << "Unable to deserialize ResourceStatistics: "
-                       << resourceStatistics.error();
-          return emptyStats(now);
-        }
-        return resourceStatistics.get();
-      })
-      .recover([now=now](const Future<::mesos::ResourceStatistics>& result)
-                   -> Future<::mesos::ResourceStatistics> {
-        LOG(WARNING) << "Failed to run usage command: " << result;
-        return emptyStats(now);
-      });
+                  if (resourceStatistics.isError()) {
+                    LOG(WARNING) << "Unable to deserialize ResourceStatistics: "
+                                 << resourceStatistics.error();
+                    return emptyStats(now);
+                  }
+                  return resourceStatistics.get();
+                })
+      .recover([now = now](const Future<::mesos::ResourceStatistics>& result)
+                   ->Future<::mesos::ResourceStatistics> {
+                     LOG(WARNING) << "Failed to run usage command: " << result;
+                     return emptyStats(now);
+                   });
 }
 
 process::Future<Nothing> CommandIsolatorProcess::cleanup(

--- a/src/CommandIsolator.cpp
+++ b/src/CommandIsolator.cpp
@@ -173,7 +173,7 @@ process::Future<::mesos::ResourceStatistics> CommandIsolatorProcess::usage(
       })
       .recover([now=now](const Future<::mesos::ResourceStatistics>& result)
                    -> Future<::mesos::ResourceStatistics> {
-        LOG(WARNING) << "Failed to run usage command: " << result.failure();
+        LOG(WARNING) << "Failed to run usage command: " << result;
         return emptyStats(now);
       });
 }

--- a/src/CommandIsolator.hpp
+++ b/src/CommandIsolator.hpp
@@ -57,10 +57,7 @@ class CommandIsolator : public ::mesos::slave::Isolator {
    * return true to support to support nested containers (especially in task
    * groupd)
    */
-  virtual bool supportsNesting()
-  {
-    return true;
-  }
+  virtual bool supportsNesting() { return true; }
 
   /**
    * Run an external command on prepare phase of a new container.

--- a/src/CommandRunner.cpp
+++ b/src/CommandRunner.cpp
@@ -160,8 +160,8 @@ Future<Try<bool>> runCommandWithTimeout(
             Try<std::list<os::ProcessTree>> kill =
                 os::killtree(process.pid(), SIGTERM);
             if (kill.isError()) {
-              TASK_LOG(ERROR, loggingMetadata)
-                  << "Failed to send SIGTERM: " << kill.error();
+              TASK_LOG(ERROR, loggingMetadata) << "Failed to send SIGTERM: "
+                                               << kill.error();
             }
             return after(Seconds(1)).then([=]() -> Future<Try<bool>> {
               if (processStillRunning(process.pid())) {
@@ -201,9 +201,9 @@ Future<Try<string>> CommandRunner::asyncRun(const Command& command,
           << command.timeout() << "s) " << inputFile.filepath() << " "
           << outputFile.filepath() << " " << errorFile.filepath();
     } else {
-      TASK_LOG(INFO, m_loggingMetadata)
-          << "Calling command: \"" << command.command() << "\" ("
-          << command.timeout() << "s)";
+      TASK_LOG(INFO, m_loggingMetadata) << "Calling command: \""
+                                        << command.command() << "\" ("
+                                        << command.timeout() << "s)";
     }
 
     vector<string> args = {inputFile.filepath(), outputFile.filepath(),
@@ -220,17 +220,18 @@ Future<Try<string>> CommandRunner::asyncRun(const Command& command,
           }
           return os::read(outputFile.filepath());
         })
-        .onAny([=, loggingMetadata = m_loggingMetadata](
-                   Future<Try<string>> output) -> Future<Try<string>> {
-          if (m_debug)
-            TASK_LOG(INFO, loggingMetadata)
-                << "Removing temp files " << inputFile << " " << outputFile
-                << " " << errorFile;
-          os::rm(inputFile.filepath());
-          os::rm(outputFile.filepath());
-          os::rm(errorFile.filepath());
-          return output;
-        });
+        .onAny([ =, loggingMetadata =
+                        m_loggingMetadata ](Future<Try<string>> output)
+                   ->Future<Try<string>> {
+                     if (m_debug)
+                       TASK_LOG(INFO, loggingMetadata)
+                           << "Removing temp files " << inputFile << " "
+                           << outputFile << " " << errorFile;
+                     os::rm(inputFile.filepath());
+                     os::rm(outputFile.filepath());
+                     os::rm(errorFile.filepath());
+                     return output;
+                   });
   } catch (const std::runtime_error& e) {
     if (m_debug) {
       return Error("[DEBUG] " + string(e.what()) + ". Input was \"" + input +

--- a/src/ConfigurationParser.cpp
+++ b/src/ConfigurationParser.cpp
@@ -1,7 +1,7 @@
 #include "ConfigurationParser.hpp"
 
-#include <stout/foreach.hpp>
 #include <map>
+#include <stout/foreach.hpp>
 
 namespace criteo {
 namespace mesos {

--- a/tests/CommandIsolatorTest.cpp
+++ b/tests/CommandIsolatorTest.cpp
@@ -255,3 +255,22 @@ TEST_F(TimeoutCommandIsolatorTest, should_return_empty_stats_on_usage_timeout) {
   EXPECT_EQ(0, stats.get().cpus_system_time_secs());
   EXPECT_TRUE(stats.get().has_timestamp());
 }
+
+class LongCommandIsolatorTest : public CommandIsolatorTest {
+ public:
+  void SetUp() {
+    CommandIsolatorTest::SetUp();
+    isolator.reset(new CommandIsolator(
+        None(), None(), None(),
+        Command(g_resourcesPath + "usage_long.sh", 1)
+        ));
+  }
+  std::unique_ptr<CommandIsolator> isolator;
+};
+
+TEST_F(LongCommandIsolatorTest,
+       should_run_usage_command_and_does_not_crash_if_discarded) {
+  auto future = isolator->usage(containerId);
+  future.discard();
+  AWAIT_ASSERT_READY_FOR(future, Seconds(3));
+}

--- a/tests/scripts/usage_long.sh
+++ b/tests/scripts/usage_long.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sleep 0.5


### PR DESCRIPTION
failure() method can be called only when future is failed.
recover callback can be called upon future failure, discard & abandon.
On some occasions (abandon & discard) we were seing:

```
I0814 15:12:50.057291  2474 CommandRunner.cpp:226] [TASK=5f946bbd-6a14-4806-bea5-9da7cbe95720, METHOD=usage] Removing temp files /tmp/criteo-mesos-cqvg3g /tm
ABORT: (../3rdparty/libprocess/include/process/future.hpp:1326): Future::failure() but state != FAILED
*** Aborted at 1565795570 (unix time) try "date -d @1565795570" if you are using GNU date ***
PC: @     0x7fae0c3d3207 __GI_raise
*** SIGABRT (@0x990) received by PID 2448 (TID 0x7fae01127700) from PID 2448; stack trace: ***
@     0x7fae0cc965d0 (unknown)
@     0x7fae0c3d3207 __GI_raise
@     0x7fae0c3d48f8 __GI_abort
@     0x5564c5a5044c (unknown)
@     0x7fae1929ea31 (unknown)
[...]
```

This patch will properly display status of the future since it defines << operator.

Change-Id: I66a059f0e64593441690836f836577ab67d9776c
Internal-link: https://confluence.criteois.com/x/zTOuHQ