### PR TITLE
Add ContainerConfig in input Json of usage/watch/cleanup callbacks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV MESOS_BUILD_DIR=/src/mesos/build
 ENV MESOS_ROOT_DIR=/src/mesos
 
 COPY scripts/llvm-3.8.0.repo /etc/yum.repos.d/
-RUN yum install -y cmake clang-3.8.0 clang-format
+RUN yum install -y cmake clang-3.8.0 clang-format jq
 ENV PATH="${PATH}:/opt/llvm-3.8.0/bin"
 
 VOLUME ["/src/mesos-command-modules"]

--- a/src/CommandIsolator.cpp
+++ b/src/CommandIsolator.cpp
@@ -68,6 +68,7 @@ class CommandIsolatorProcess : public process::Process<CommandIsolatorProcess> {
   Option<Command> m_cleanupCommand;
   Option<Command> m_usageCommand;
   bool m_isDebugMode;
+  hashmap<ContainerID, ContainerConfig> m_infos;
 };
 
 CommandIsolatorProcess::CommandIsolatorProcess(
@@ -83,6 +84,11 @@ CommandIsolatorProcess::CommandIsolatorProcess(
 
 process::Future<Option<ContainerLaunchInfo>> CommandIsolatorProcess::prepare(
     const ContainerID& containerId, const ContainerConfig& containerConfig) {
+  if (m_infos.contains(containerId)) {
+    return Failure("mesos-command-module already initialized for container");
+  } else {
+    m_infos.put(containerId, containerConfig);
+  }
   if (m_prepareCommand.isNone()) {
     return None();
   }
@@ -124,6 +130,10 @@ process::Future<ContainerLimitation> CommandIsolatorProcess::watch(
 
   JSON::Object inputsJson;
   inputsJson.values["container_id"] = JSON::protobuf(containerId);
+  if (m_infos.contains(containerId)) {
+    inputsJson.values["container_config"] =
+        JSON::protobuf(m_infos[containerId]);
+  }
 
   std::string inputStringified = stringify(inputsJson);
   RecurrentCommand command = m_watchCommand.get();
@@ -180,6 +190,10 @@ process::Future<::mesos::ResourceStatistics> CommandIsolatorProcess::usage(
 
   JSON::Object inputsJson;
   inputsJson.values["container_id"] = JSON::protobuf(containerId);
+  if (m_infos.contains(containerId)) {
+    inputsJson.values["container_config"] =
+        JSON::protobuf(m_infos[containerId]);
+  }
 
   return CommandRunner(m_isDebugMode, metadata)
       .asyncRun(m_usageCommand.get(), stringify(inputsJson))
@@ -214,6 +228,9 @@ process::Future<::mesos::ResourceStatistics> CommandIsolatorProcess::usage(
 process::Future<Nothing> CommandIsolatorProcess::cleanup(
     const ContainerID& containerId) {
   if (m_cleanupCommand.isNone()) {
+    if (m_infos.contains(containerId)) {
+      m_infos.erase(containerId);
+    }
     return Nothing();
   }
 
@@ -221,10 +238,17 @@ process::Future<Nothing> CommandIsolatorProcess::cleanup(
 
   JSON::Object inputsJson;
   inputsJson.values["container_id"] = JSON::protobuf(containerId);
+  if (m_infos.contains(containerId)) {
+    inputsJson.values["container_config"] =
+        JSON::protobuf(m_infos[containerId]);
+  }
 
   Try<string> output = CommandRunner(m_isDebugMode, metadata)
                            .run(m_cleanupCommand.get(), stringify(inputsJson));
 
+  if (m_infos.contains(containerId)) {
+    m_infos.erase(containerId);
+  }
   if (output.isError()) {
     return Failure(output.error());
   }

--- a/tests/CommandIsolatorTest.cpp
+++ b/tests/CommandIsolatorTest.cpp
@@ -16,37 +16,50 @@ class CommandIsolatorTest : public ::testing::Test {
  protected:
   ContainerID containerId;
   ContainerConfig containerConfig;
+  process::Future<Option<ContainerLaunchInfo>> containerLaunchInfoFuture;
 
  public:
   void SetUp() {
-    isolator.reset(
-        new CommandIsolator(Command(g_resourcesPath + "prepare.sh"),
-                            RecurrentCommand(g_resourcesPath + "watch.sh", 3, 0.1),
-                            Command(g_resourcesPath + "cleanup.sh"),
-                            Command(g_resourcesPath + "usage.sh")));
     containerId.set_value("container_id");
-
     containerConfig.set_rootfs("/isolated_fs");
     containerConfig.set_user("app_user");
   }
+  void Prepare() {
+      containerLaunchInfoFuture =
+        isolator->prepare(containerId, containerConfig);
+      AWAIT_READY(containerLaunchInfoFuture);
+  }
+  void PrepareFailed() {
+      containerLaunchInfoFuture =
+        isolator->prepare(containerId, containerConfig);
+      AWAIT_FAILED(containerLaunchInfoFuture);
+    }
 
   std::unique_ptr<CommandIsolator> isolator;
 };
 
-TEST_F(CommandIsolatorTest,
+class CommandIsolatorSimpleTest : public CommandIsolatorTest {
+public:
+  void SetUp() {
+    CommandIsolatorTest::SetUp();
+    isolator.reset(
+      new CommandIsolator(Command(g_resourcesPath + "prepare.sh"),
+                          RecurrentCommand(g_resourcesPath + "watch.sh", 3, 0.1),
+                          Command(g_resourcesPath + "cleanup.sh"),
+                          Command(g_resourcesPath + "usage.sh")));
+    CommandIsolatorTest::Prepare();
+  }
+};
+
+TEST_F(CommandIsolatorSimpleTest,
        should_run_prepare_command_and_retrieve_container_launch_info) {
-  auto containerLaunchInfoFuture =
-      isolator->prepare(containerId, containerConfig);
-
-  AWAIT_READY(containerLaunchInfoFuture);
-
   Option<ContainerLaunchInfo> launchInfo = containerLaunchInfoFuture.get();
 
   EXPECT_EQ("/isolated_fs", launchInfo->rootfs());
   EXPECT_EQ("app_user", launchInfo->user());
 }
 
-TEST_F(CommandIsolatorTest,
+TEST_F(CommandIsolatorSimpleTest,
        should_run_watch_command_and_retrieve_container_limitation) {
   auto containerLimitation = isolator->watch(containerId);
 
@@ -57,13 +70,13 @@ TEST_F(CommandIsolatorTest,
   EXPECT_EQ("too much toto", limited.message());
 }
 
-TEST_F(CommandIsolatorTest,
+TEST_F(CommandIsolatorSimpleTest,
        should_run_cleanup_command_and_terminates_successfully) {
   auto future = isolator->cleanup(containerId);
   AWAIT_READY(future);
 }
 
-TEST_F(CommandIsolatorTest,
+TEST_F(CommandIsolatorSimpleTest,
        should_run_usage_command_and_retrieve_container_limitation) {
   auto resourceStatistics = isolator->usage(containerId);
 
@@ -74,33 +87,21 @@ TEST_F(CommandIsolatorTest,
   EXPECT_EQ(5, stats.net_snmp_statistics().tcp_stats().currestab());
 }
 
-class CommandIsolatorContinuousTest : public ::testing::Test {
-protected:
-  ContainerID containerId;
-  ContainerConfig containerConfig;
-
+class CommandIsolatorContinuousTest : public CommandIsolatorTest {
 public:
   void SetUp() {
+    CommandIsolatorTest::SetUp();
     isolator.reset(
       new CommandIsolator(Command(g_resourcesPath + "prepare.sh"),
                           RecurrentCommand(g_resourcesPath + "watch_continuous.sh", 3, 0.1),
                           Command(g_resourcesPath + "cleanup.sh"),
                           Command(g_resourcesPath + "usage_continuous.sh")));
-    containerId.set_value("other_container_id");
-
-    containerConfig.set_rootfs("/isolated_fs");
-    containerConfig.set_user("app_user");
+    CommandIsolatorTest::Prepare();
   }
-
-  std::unique_ptr<CommandIsolator> isolator;
 };
 
 TEST_F(CommandIsolatorContinuousTest,
   should_run_prepare_watch_usage_and_cleanup_commands) {
-  auto containerLaunchInfoFuture =
-    isolator->prepare(containerId, containerConfig);
-  AWAIT_READY(containerLaunchInfoFuture);
-
   auto containerLimitation = isolator->watch(containerId);
   AWAIT_READY(containerLimitation);
   ContainerLimitation limited = containerLimitation.get();
@@ -125,15 +126,9 @@ class UnexistingCommandIsolatorTest : public CommandIsolatorTest {
                                        Command("unexisting.sh"),
                                        Command("unexisting.sh")
                                        ));
+    CommandIsolatorTest::PrepareFailed();
   }
-  std::unique_ptr<CommandIsolator> isolator;
 };
-
-TEST_F(UnexistingCommandIsolatorTest,
-       should_try_to_run_prepare_command_and_fail) {
-  auto future = isolator->prepare(containerId, containerConfig);
-  AWAIT_FAILED(future);
-}
 
 TEST_F(UnexistingCommandIsolatorTest,
        should_try_to_run_watch_command_and_fail) {
@@ -158,15 +153,9 @@ class MalformedCommandIsolatorTest : public CommandIsolatorTest {
         None(),
         Command(g_resourcesPath + "usage_malformed.sh")
         ));
+    CommandIsolatorTest::PrepareFailed();
   }
-  std::unique_ptr<CommandIsolator> isolator;
 };
-
-TEST_F(MalformedCommandIsolatorTest,
-       should_run_prepare_command_and_handle_malformed_output_json) {
-  auto future = isolator->prepare(containerId, containerConfig);
-  AWAIT_FAILED(future);
-}
 
 TEST_F(MalformedCommandIsolatorTest,
        should_run_watch_command_and_handle_malformed_output_json) {
@@ -189,16 +178,14 @@ class EmptyCommandIsolatorTest : public CommandIsolatorTest {
   void SetUp() {
     CommandIsolatorTest::SetUp();
     isolator.reset(new CommandIsolator(None(), None(), None(), None()));
+    CommandIsolatorTest::Prepare();
   }
-  std::unique_ptr<CommandIsolator> isolator;
 };
 
 TEST_F(
     EmptyCommandIsolatorTest,
     should_resolve_promise_and_return_null_option_when_prepare_command_is_empty) {
-  auto future = isolator->prepare(containerId, containerConfig);
-  AWAIT_READY(future);
-  EXPECT_TRUE(future->isNone());
+  EXPECT_TRUE(containerLaunchInfoFuture->isNone());
 }
 
 TEST_F(EmptyCommandIsolatorTest,
@@ -233,15 +220,9 @@ class IncorrectProtobufCommandIsolatorTest : public CommandIsolatorTest {
         None(),
         Command(g_resourcesPath + "usage_incorrect_protobuf.sh")
         ));
+    CommandIsolatorTest::PrepareFailed();
   }
-  std::unique_ptr<CommandIsolator> isolator;
 };
-
-TEST_F(IncorrectProtobufCommandIsolatorTest,
-       should_run_prepare_command_and_handle_incorrect_protobuf_output) {
-  auto future = isolator->prepare(containerId, containerConfig);
-  AWAIT_FAILED(future);
-}
 
 TEST_F(IncorrectProtobufCommandIsolatorTest,
        should_run_watch_command_and_handle_incorrect_protobuf_output) {
@@ -267,8 +248,8 @@ class EmptyOutputCommandIsolatorTest : public CommandIsolatorTest {
         None(), RecurrentCommand(g_resourcesPath + "watch_empty.sh", 3, 0.1), None(),
         Command(g_resourcesPath + "usage_empty.sh")
         ));
+    CommandIsolatorTest::Prepare();
   }
-  std::unique_ptr<CommandIsolator> isolator;
 };
 
 TEST_F(EmptyOutputCommandIsolatorTest,
@@ -293,8 +274,8 @@ class TimeoutCommandIsolatorTest : public CommandIsolatorTest {
         None(), None(), None(),
         Command(g_resourcesPath + "usage_timeout.sh", 1)
         ));
+    CommandIsolatorTest::Prepare();
   }
-  std::unique_ptr<CommandIsolator> isolator;
 };
 
 TEST_F(TimeoutCommandIsolatorTest, should_return_empty_stats_on_usage_timeout) {
@@ -312,8 +293,8 @@ class LongCommandIsolatorTest : public CommandIsolatorTest {
         None(), None(), None(),
         Command(g_resourcesPath + "usage_long.sh", 1)
         ));
+    CommandIsolatorTest::Prepare();
   }
-  std::unique_ptr<CommandIsolator> isolator;
 };
 
 TEST_F(LongCommandIsolatorTest,

--- a/tests/scripts/usage_continuous.sh
+++ b/tests/scripts/usage_continuous.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+USER=$(cat $1 | jq ".[\"container_config\"][\"user\"]"|sed -e "s/\"//g")
+if [ -n "$USER" ]
+then
+    echo '{"timestamp": 1, "net_snmp_statistics": {"tcp_stats": { "CurrEstab": 5}}}' >$2
+else
+    echo '{"timestamp": 0, "net_snmp_statistics": {"tcp_stats": { "CurrEstab": 5}}}' >$2
+fi

--- a/tests/scripts/watch_continuous.sh
+++ b/tests/scripts/watch_continuous.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+USER=$(cat $1 | jq ".[\"container_config\"][\"user\"]"|sed -e "s/\"//g")
+if [ -n "$USER" ]
+then
+    echo '{"resources":[{"name":"toto","type":"SCALAR","scalar":{"value":1}}],"message":"user found","reason":"REASON_CONTAINER_LIMITATION"}' >$2
+fi


### PR DESCRIPTION
In some isolator callbacks it may be useful to have more information than just the container ID. In mesos core isolators, prepare callback gets the ContainerConfiguration so it can be partially copied in an internal structure and pass to watch/usage/cleanup callbacks. This PR offers a way to save full ContainerConfiguration and pass it to all Isolator callbacks as part of the json input file.