### PR TITLE
Don't use libprocess to run watch command in watch loop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ set(MODULES_SOURCES
   ${CMAKE_SOURCE_DIR}/src/CommandHook.cpp
   ${CMAKE_SOURCE_DIR}/src/CommandIsolator.cpp
   ${CMAKE_SOURCE_DIR}/src/CommandRunner.cpp
+  ${CMAKE_SOURCE_DIR}/src/RunningContext.cpp
   ${CMAKE_SOURCE_DIR}/src/ConfigurationParser.cpp
   ${CMAKE_SOURCE_DIR}/src/ModulesFactory.cpp
 )
@@ -66,6 +67,7 @@ set(MODULES_HEADERS
   ${CMAKE_SOURCE_DIR}/src/CommandHook.hpp
   ${CMAKE_SOURCE_DIR}/src/CommandIsolator.hpp
   ${CMAKE_SOURCE_DIR}/src/CommandRunner.hpp
+  ${CMAKE_SOURCE_DIR}/src/RunningContext.hpp
   ${CMAKE_SOURCE_DIR}/src/ConfigurationParser.hpp
   ${CMAKE_SOURCE_DIR}/src/Helpers.hpp
   ${CMAKE_SOURCE_DIR}/src/Logger.hpp

--- a/src/CommandRunner.hpp
+++ b/src/CommandRunner.hpp
@@ -45,6 +45,14 @@ class CommandRunner {
                        const std::string& serializedInput);
 
   /**
+   * Run a command synchonously without timeout and without using libprocess.
+   * Using libprocess in the watch loop can generate some deadlocks in
+   * libprocess.
+   */
+  Try<std::string> runWithoutTimeout(const Command& command,
+                                     const std::string& input);
+
+  /**
    * Run a command asynchonously.
    * This method leverages libprocess primitives to avoid blocking unnecessarily
    * while waiting for the command's output.

--- a/src/RunningContext.cpp
+++ b/src/RunningContext.cpp
@@ -1,0 +1,78 @@
+#include "RunningContext.hpp"
+
+#include <fstream>
+#include <stout/os.hpp>
+
+namespace criteo {
+namespace mesos {
+
+RunningContext::TemporaryFile::TemporaryFile() {
+  char filepath[] = TEMP_FILE_TEMPLATE;
+  int fd = mkstemp(filepath);
+  if (fd == -1)
+    throw std::runtime_error("Unable to create temporary file to run commands");
+  close(fd);
+  m_filepath = std::string(filepath);
+}
+
+std::string RunningContext::TemporaryFile::readAll() const {
+  std::ifstream ifs(m_filepath);
+  std::string content((std::istreambuf_iterator<char>(ifs)),
+                      (std::istreambuf_iterator<char>()));
+  ifs.close();
+  return content;
+}
+
+void RunningContext::TemporaryFile::write(const std::string& content) const {
+  std::ofstream ofs;
+  ofs.open(m_filepath);
+  ofs << content;
+  std::flush(ofs);
+  ofs.close();
+}
+
+inline const std::string& RunningContext::TemporaryFile::filepath() const {
+  return m_filepath;
+}
+
+RunningContext::RunningContext(bool debug,
+                               const logging::Metadata& loggingMetadata,
+                               const Command& command, const std::string& input)
+    : debug(debug), loggingMetadata(loggingMetadata) {
+  inputFile.write(input);
+  args = {inputFile.filepath(), outputFile.filepath(), errorFile.filepath()};
+
+  if (debug) {
+    TASK_LOG(INFO, loggingMetadata)
+        << "Calling command: \"" << command.command() << "\" ("
+        << command.timeout() << "s) " << inputFile.filepath() << " "
+        << outputFile.filepath() << " " << errorFile.filepath();
+  } else {
+    TASK_LOG(INFO, loggingMetadata) << "Calling command: \""
+                                    << command.command() << "\" ("
+                                    << command.timeout() << "s)";
+  }
+}
+
+void RunningContext::deleteContext() const {
+  if (debug)
+    TASK_LOG(INFO, loggingMetadata) << "Removing temp files " << inputFile
+                                    << " " << outputFile << " " << errorFile;
+  os::rm(inputFile.filepath());
+  os::rm(outputFile.filepath());
+  os::rm(errorFile.filepath());
+}
+
+Try<std::string> RunningContext::readOutput() const {
+  return readFile(outputFile);
+}
+
+Try<std::string> RunningContext::readError() const {
+  return readFile(errorFile);
+}
+
+Try<std::string> RunningContext::readFile(const TemporaryFile& file) const {
+  return os::read(file.filepath());
+}
+}  // namespace mesos
+}  // namespace criteo

--- a/src/RunningContext.hpp
+++ b/src/RunningContext.hpp
@@ -1,0 +1,69 @@
+#ifndef __RUNNING_CONTEXT_HPP__
+#define __RUNNING_CONTEXT_HPP__
+
+#include <stout/try.hpp>
+
+#include "Command.hpp"
+#include "Logger.hpp"
+
+#define TEMP_FILE_TEMPLATE "/tmp/criteo-mesos-XXXXXX"
+
+namespace criteo {
+namespace mesos {
+
+class RunningContext {
+ public:
+  RunningContext(bool debug, const logging::Metadata& loggingMetadata,
+                 const Command& command, const std::string& input);
+
+  void deleteContext() const;
+  Try<std::string> readOutput() const;
+  Try<std::string> readError() const;
+  const std::vector<std::string>& get_args() const { return args; };
+
+ private:
+  /*
+   * Represent a temporary file that can be either written or read from.
+   */
+  class TemporaryFile {
+   public:
+    TemporaryFile();
+
+    /*
+     * Read whole content of the temporary file.
+     * @return The content of the file.
+     */
+    std::string readAll() const;
+
+    /*
+     * Write content to the temporary file and flush it.
+     * @param content The content to write to the file.
+     */
+    void write(const std::string& content) const;
+
+    inline const std::string& filepath() const;
+
+    friend std::ostream& operator<<(std::ostream& out,
+                                    const TemporaryFile& temp_file) {
+      out << temp_file.m_filepath;
+      return out;
+    }
+
+   private:
+    std::string m_filepath;
+  };
+
+  Try<std::string> readFile(const TemporaryFile& file) const;
+
+  bool debug;
+  const logging::Metadata& loggingMetadata;
+  std::vector<std::string> args;
+
+  TemporaryFile inputFile;
+  TemporaryFile outputFile;
+  TemporaryFile errorFile;
+};
+
+}  // namespace mesos
+}  // namespace criteo
+#endif  // __RUNNING_CONTEXT_HPP__

--- a/tests/CommandIsolatorTest.cpp
+++ b/tests/CommandIsolatorTest.cpp
@@ -55,6 +55,7 @@ TEST_F(CommandIsolatorTest,
   ContainerLimitation limited = containerLimitation.get();
 
   EXPECT_EQ("too much toto", limited.message());
+  containerLimitation.discard();
 }
 
 TEST_F(CommandIsolatorTest,


### PR DESCRIPTION
Using libprocess in the watch loop can generate some deadlocks in libprocess when the underlying process is killed.
We also don't need to asynchronously run the commands in the watch loop.