### PR TITLE
Decrease log verbosity

### DIFF
--- a/src/RunningContext.cpp
+++ b/src/RunningContext.cpp
@@ -47,10 +47,6 @@ RunningContext::RunningContext(bool debug,
         << "Calling command: \"" << command.command() << "\" ("
         << command.timeout() << "s) " << inputFile.filepath() << " "
         << outputFile.filepath() << " " << errorFile.filepath();
-  } else {
-    TASK_LOG(INFO, loggingMetadata) << "Calling command: \""
-                                    << command.command() << "\" ("
-                                    << command.timeout() << "s)";
   }
 }
 


### PR DESCRIPTION
Logging command call is very verbose (especially for "usage" method of
the isolator). We don't really need that unless running in debug mode.

Change-Id: I0ab9fe4a0d85f5dfbb2cc519d47ae0e273b2dad6