### PR TITLE
Auto terminate watch loop

### DIFF
--- a/src/CommandIsolator.cpp
+++ b/src/CommandIsolator.cpp
@@ -151,9 +151,17 @@ process::Future<ContainerLimitation> CommandIsolatorProcess::watch(
                                  .runWithoutTimeout(command, inputStringified);
         return output;
       },
-      [command](
+      [command, this, containerId](
           Try<string> output) -> Future<ControlFlow<ContainerLimitation>> {
         try {
+          if (!m_infos.contains(containerId)) {
+            LOG(WARNING) << "Terminating watch loop for containerId: "
+                         << containerId;
+            // Returning a discarded future stops the loop
+            Future<ControlFlow<ContainerLimitation>> ret;
+            ret.discard();
+            return ret;
+          }
           if (output.isError())
             throw std::runtime_error("Unable to parse output: " +
                                      output.error());

--- a/src/CommandIsolator.hpp
+++ b/src/CommandIsolator.hpp
@@ -13,6 +13,8 @@
 namespace criteo {
 namespace mesos {
 
+class should_continue_exception : public std::exception {};
+
 // Forward declaration
 class CommandIsolatorProcess;
 

--- a/src/CommandRunner.cpp
+++ b/src/CommandRunner.cpp
@@ -184,7 +184,8 @@ Try<string> CommandRunner::runWithoutTimeout(const Command& command,
   }
   if (ret) {
     Try<string> stderr = rc.readError();
-    std::string errMsg = "Command exited with exit code: " + ret;
+    std::string errMsg =
+        "Command exited with exit code: " + std::to_string(WEXITSTATUS(ret));
     if (stderr.isError() || stderr.get().empty()) return Error(errMsg);
     return Error(errMsg + " Cause: " + stderr.get());
   }


### PR DESCRIPTION
This fixes a couple of things regarding the watch loop:

* Terminate watch loop when container is deleted
* Fix printed blank lines
* Fix exit code display