### PR TITLE
Fix debug 🐞

### DIFF
--- a/src/RunningContext.hpp
+++ b/src/RunningContext.hpp
@@ -56,7 +56,7 @@ class RunningContext {
   Try<std::string> readFile(const TemporaryFile& file) const;
 
   bool debug;
-  const logging::Metadata& loggingMetadata;
+  const logging::Metadata loggingMetadata;
   std::vector<std::string> args;
 
   TemporaryFile inputFile;


### PR DESCRIPTION
One-char fixes are the best!

Rational for the fix: the lambda was copy-capturing the RunningContext object, which only references the logging metadata. When the lambda was effectively called after the destruction of the original RunningContext object (and its logging metadata), the local metadata pointed to invalid memory.