### PR TITLE
Update Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 ---
-sudo: required
+
+dist: xenial
+os: linux
+language: cpp
 
 services:
   - docker


### PR DESCRIPTION
Fixed the following warnings:
- `root`: deprecated key sudo (The key `sudo` has no effect anymore.)
- `root`: missing `dist`, using the default `xenial`
- `root`: missing `os`, using the default `linux`
- `root`: missing `language`, using the default `ruby`